### PR TITLE
Don't crash when writing files on 64bit machines

### DIFF
--- a/pyedflib/_extensions/c/edflib.c
+++ b/pyedflib/_extensions/c/edflib.c
@@ -29,11 +29,7 @@
 */
 
 
-
-
 /* compile with options "-D_LARGEFILE64_SOURCE -D_LARGEFILE_SOURCE" */
-
-
 
 
 #include "edflib.h"

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,8 @@ cython_modules = ['_pyedflib']
 cython_sources = [('{0}.pyx' if USE_CYTHON else '{0}.c').format(module)
                   for module in cython_modules]
 
-c_macros = [("PY_EXTENSION", None)]
+c_macros = [("PY_EXTENSION", None), ("_LARGEFILE64_SOURCE", None), ("_LARGEFILE_SOURCE", None)]
+
 cython_macros = []
 cythonize_opts = {}
 if os.environ.get("CYTHON_TRACE"):
@@ -136,7 +137,7 @@ ext_modules = [
               depends=c_lib[1]['sources'] + c_lib[1]['depends'],
               include_dirs=[make_ext_path("c"), get_numpy_include()],
               define_macros=c_macros + cython_macros,
-              libraries=[c_lib[0]],)
+              libraries=[c_lib[0]])
     for module, source, in zip(cython_modules, cython_sources)
 ]
 


### PR DESCRIPTION
Hi!
If you tried to write an EDF file on an amd64 machine (and possible even any other machine) using this Python module, you ran into a segmentation fault:
```
Program received signal SIGSEGV, Segmentation fault.
__GI_rewind (fp=fp@entry=0x566f34a0) at rewind.c:34
34      rewind.c: Datei oder Verzeichnis nicht gefunden.
#0  __GI_rewind (fp=fp@entry=0x566f34a0) at rewind.c:34
#1  0x00007fffec7471bb in edflib_write_edf_header (hdr=hdr@entry=0x555556789bb0) at pyedflib/_extensions/c/edflib.c:4873
#2  0x00007fffec74c3ea in edf_blockwrite_physical_samples (handle=handle@entry=0, buf=<optimized out>)
    at pyedflib/_extensions/c/edflib.c:4710
```

This happens because the `fopen64` and other functions are not defined. The compiler even warns about that and I thought about making that warning fatal while writing this patch...

The problem is that if a reference is undefined, the functions will be assumed, as per C standard, to return an int datatype, which is not large enough to hold a pointer to `FILE*` on 64bit devices. Therefore, the pointer gets smashed and any subsequent action on it is doomed to fail and crash the program.

The solution is to always compile with large file support, so the respective functions are defined. This will also get rid of almost all compiler warnings (the edflib.c file even contains a note about this at its top, so it looks like its original author was aware of this problem).

To reproduce the bug, just try to run the `demo/writeEDFFile.py` on an amd64 machine.

Cheers,
    Matthias