### PR TITLE
Add utf-8 codec argument to unicode call in _convert_string

### DIFF
--- a/pyedflib/edfreader.py
+++ b/pyedflib/edfreader.py
@@ -83,7 +83,7 @@ class EdfReader(CyEdfReader):
             # unicode = lambda s: str(s)
             UNICODE_EXISTS = False
         if UNICODE_EXISTS:
-            return unicode(s)
+            return unicode(s, "utf-8")
         else:
             return s.decode("utf-8", "strict")
 


### PR DESCRIPTION
Based on the call to s.decode, it looks like the intent here is to use the utf-8 codec. Failure to specify this explicitly in the unicode() call was causing exceptions for me when reading annotations from a file that had non-ASCII characters in them