### PR TITLE
Included digital support

### DIFF
--- a/pyedflib/edfwriter.py
+++ b/pyedflib/edfwriter.py
@@ -658,7 +658,7 @@ class EdfWriter(object):
             raise WrongInputSize(len(data_list))
             
         if digital:
-            if any([a.dtype!=np.int for a in data_list]):
+            if any([not np.issubdtype(a.dtype, np.integer) for a in data_list]):
                 raise TypeError('Digital = True requires all signals in int')
 
 

--- a/pyedflib/edfwriter.py
+++ b/pyedflib/edfwriter.py
@@ -636,7 +636,7 @@ class EdfWriter(object):
     def blockWriteDigitalShortSamples(self, data):
         return blockwrite_digital_short_samples(self.handle, data)
 
-    def writeSamples(self, data_list):
+    def writeSamples(self, data_list, digital = False):
         """
         Writes physical samples (uV, mA, Ohm) from data belonging to all signals
         The physical samples will be converted to digital samples using the values
@@ -646,12 +646,21 @@ class EdfWriter(object):
         is different, then sample_freq is a vector containing all the different
         samplefrequencys. The data is saved as list. Each list entry contains
         a vector with the data of one signal.
+        
+        If digital is True, digital signals (as directly from the ADC) will be expected.
+        (e.g. int16 from 0 to 2048)
 
         All parameters must be already written into the bdf/edf-file.
         """
 
+
         if (len(data_list) != len(self.channels)):
             raise WrongInputSize(len(data_list))
+            
+        if digital:
+            if any([a.dtype!=np.int for a in data_list]):
+                raise TypeError('Digital = True requires all signals in int')
+
 
         ind = []
         notAtEnd = True
@@ -659,40 +668,47 @@ class EdfWriter(object):
             ind.append(0)
 
         sampleLength = 0
-        sampleRates = np.zeros(len(data_list), dtype=int)
+        sampleRates = np.zeros(len(data_list), dtype=np.int)
         for i in np.arange(len(data_list)):
             sampleRates[i] = self.channels[i]['sample_rate']
             if (np.size(data_list[i]) < ind[i] + self.channels[i]['sample_rate']):
                 notAtEnd = False
             sampleLength += self.channels[i]['sample_rate']
 
-        dataOfOneSecond = np.array([])
+        dataOfOneSecond = np.array([], dtype=np.int if digital else None)
 
         while notAtEnd:
             # dataOfOneSecondInd = 0
             del dataOfOneSecond
-            dataOfOneSecond = np.array([])
+            dataOfOneSecond = np.array([], dtype=np.int if digital else None)
             for i in np.arange(len(data_list)):
                 # dataOfOneSecond[dataOfOneSecondInd:dataOfOneSecondInd+self.channels[i]['sample_rate']] = data_list[i].ravel()[int(ind[i]):int(ind[i]+self.channels[i]['sample_rate'])]
                 dataOfOneSecond = np.append(dataOfOneSecond,data_list[i].ravel()[int(ind[i]):int(ind[i]+sampleRates[i])])
                 # self.writePhysicalSamples(data_list[i].ravel()[int(ind[i]):int(ind[i]+self.channels[i]['sample_rate'])])
                 ind[i] += sampleRates[i]
                 # dataOfOneSecondInd += sampleRates[i]
-            self.blockWritePhysicalSamples(dataOfOneSecond)
+            if digital:
+                self.blockWriteDigitalSamples(dataOfOneSecond)   
+            else:
+                self.blockWritePhysicalSamples(dataOfOneSecond)
+                
             for i in np.arange(len(data_list)):
                 if (np.size(data_list[i]) < ind[i] + sampleRates[i]):
                     notAtEnd = False
 
         # dataOfOneSecondInd = 0
         for i in np.arange(len(data_list)):
-            lastSamples = np.zeros(sampleRates[i])
+            lastSamples = np.zeros(sampleRates[i], dtype=np.int if digital else None)
             lastSampleInd = int(np.max(data_list[i].shape) - ind[i])
             lastSampleInd = int(np.min((lastSampleInd,sampleRates[i])))
             if lastSampleInd > 0:
                 lastSamples[:lastSampleInd] = data_list[i].ravel()[-lastSampleInd:]
                 # dataOfOneSecond[dataOfOneSecondInd:dataOfOneSecondInd+self.channels[i]['sample_rate']] = lastSamples
                 # dataOfOneSecondInd += self.channels[i]['sample_rate']
-                self.writePhysicalSamples(lastSamples)
+                if digital:
+                    self.writeDigitalSamples(lastSamples)   
+                else:
+                    self.writePhysicalSamples(lastSamples)
         # self.blockWritePhysicalSamples(dataOfOneSecond)
 
     def writeAnnotation(self, onset_in_seconds, duration_in_seconds, description, str_format='utf-8'):

--- a/pyedflib/tests/test_edfwriter.py
+++ b/pyedflib/tests/test_edfwriter.py
@@ -297,6 +297,57 @@ class TestEdfWriter(unittest.TestCase):
         np.testing.assert_equal(len(data2), len(data2_read))
         np.testing.assert_almost_equal(data1, data1_read)
         np.testing.assert_almost_equal(data2, data2_read)
+        
+    def test_SampleWriting_digital(self):
+
+        dmin, dmax = [0, 1024]
+        pmin, pmax = [0, 1.0]
+        channel_info1 = {'label':'test_label1', 'dimension':'mV', 'sample_rate':100,
+                         'physical_max':pmax,'physical_min':pmin,
+                         'digital_max':dmax,'digital_min':dmin,
+                         'prefilter':'pre1','transducer':'trans1'}
+        channel_info2 = {'label':'test_label2', 'dimension':'mV', 'sample_rate':100,
+                         'physical_max':pmax,'physical_min':pmin,
+                         'digital_max':dmax,'digital_min':dmin,
+                         'prefilter':'pre2','transducer':'trans2'}
+
+
+        f = pyedflib.EdfWriter(self.bdfplus_data_file, 2,
+                              file_type=pyedflib.FILETYPE_EDFPLUS)
+        f.setSignalHeader(0,channel_info1)
+        f.setSignalHeader(1,channel_info2)
+
+        data1 = np.arange(500, dtype=np.float)
+        data2 = np.arange(500, dtype=np.float)
+        data_list = []
+        data_list.append(data1)
+        data_list.append(data2)
+        with  np.testing.assert_raises(TypeError):
+            f.writeSamples(data_list, digital=True)
+        del f    
+
+        f = pyedflib.EdfWriter(self.bdfplus_data_file, 2,
+                              file_type=pyedflib.FILETYPE_EDFPLUS)
+        f.setSignalHeader(0,channel_info1)
+        f.setSignalHeader(1,channel_info2)
+
+        data1 = np.arange(500, dtype=np.int)
+        data2 = np.arange(500, dtype=np.int)
+        data_list = []
+        data_list.append(data1)
+        data_list.append(data2)
+        f.writeSamples(data_list, digital=True)
+        del f
+
+        f = pyedflib.EdfReader(self.bdfplus_data_file)
+        data1_read = (f.readSignal(0) - pmin)/((pmax-pmin)/(dmax-dmin)) # converting back to digital
+        data2_read = (f.readSignal(1) - pmin)/((pmax-pmin)/(dmax-dmin)) # converting back to digital
+        del f
+    
+        np.testing.assert_equal(len(data1), len(data1_read))
+        np.testing.assert_equal(len(data2), len(data2_read))
+        np.testing.assert_almost_equal(data1, data1_read)
+        np.testing.assert_almost_equal(data2, data2_read)
 
     def test_TestRoundingEDF(self):
         channel_info1 = {'label':'test_label1', 'dimension':'mV', 'sample_rate':100,


### PR DESCRIPTION
Extended the writer to write digital samples instead of physical samples, as suggested in #6 .

`pyEDFWriter.writeSamples(data_list, digital=True)` will now accept digital raw values and not convert them.

No idea if this complies with your code standards or if it makes sense at all.
It's a small patch I've written and it seems to work well.

added some tests as well.