### PR TITLE
set genders correctly

### DIFF
--- a/pyedflib/edfwriter.py
+++ b/pyedflib/edfwriter.py
@@ -147,10 +147,10 @@ class EdfWriter(object):
         set_admincode(self.handle, du(self.admincode))
         if isinstance(self.gender, int):
             set_gender(self.handle, self.gender)
-        elif self.gender == "Male":
-            set_gender(self.handle, 0)
-        elif self.gender == "Female":
+        elif self.gender.upper() in ["MALE", "M"]:
             set_gender(self.handle, 1)
+        elif self.gender.upper() in ["FEMALE", 'F']:
+            set_gender(self.handle, 0)
 
         set_datarecord_duration(self.handle, self.duration)
         set_number_of_annotation_signals(self.handle, self.number_of_annotations)

--- a/pyedflib/edfwriter.py
+++ b/pyedflib/edfwriter.py
@@ -147,9 +147,9 @@ class EdfWriter(object):
         set_admincode(self.handle, du(self.admincode))
         if isinstance(self.gender, int):
             set_gender(self.handle, self.gender)
-        elif self.gender.upper() in ["MALE", "M"]:
+        elif isinstance(self.gender,str) and self.gender.upper() in ["MALE", "M"]:
             set_gender(self.handle, 1)
-        elif self.gender.upper() in ["FEMALE", 'F']:
+        elif isinstance(self.gender,str) and self.gender.upper() in ["FEMALE", 'F']:
             set_gender(self.handle, 0)
 
         set_datarecord_duration(self.handle, self.duration)


### PR DESCRIPTION
I've figured that pyEDFlib is a gender-bender.

According to definitions of edflib (and the function header in `writeedf`), 0=Female, 1=Male.

I've fixed it, now giving 'Female' or 'F' should also write a 0