### PR TITLE
Explicitly call close when back to back writers are created since del…

### DIFF
--- a/pyedflib/tests/test_edfwriter.py
+++ b/pyedflib/tests/test_edfwriter.py
@@ -324,6 +324,7 @@ class TestEdfWriter(unittest.TestCase):
         data_list.append(data2)
         with  np.testing.assert_raises(TypeError):
             f.writeSamples(data_list, digital=True)
+        f.close()
         del f    
 
         f = pyedflib.EdfWriter(self.bdfplus_data_file, 2,


### PR DESCRIPTION
… indirectly and lazily calls __del__ which can result in a IO race condition.