### PR TITLE
Fix issues with test_EdfReader_Close_file and have it actually exerci…

### DIFF
--- a/pyedflib/tests/test_edfreader.py
+++ b/pyedflib/tests/test_edfreader.py
@@ -172,12 +172,7 @@ class TestEdfReader(unittest.TestCase):
                         'physical_max': 1.0, 'physical_min': -1.0,
                         'digital_max': 8388607, 'digital_min': -8388608,
                         'prefilter': 'pre1', 'transducer': 'trans1'}
-        try:
-            f = pyedflib.EdfWriter(self.bdf_accented_file, 1,file_type=pyedflib.FILETYPE_BDFPLUS)
-        except IOError:
-            print('cannot write', self.bdf_accented_file)
-            np.testing.assert_raises(IOError,'cannot write file')
-            return
+        f = pyedflib.EdfWriter(self.bdf_accented_file, 1,file_type=pyedflib.FILETYPE_BDFPLUS)
         f.setSignalHeader(0,channel_info)
         f.setTechnician('tec1')
         data = np.ones(100) * 0.1
@@ -185,12 +180,7 @@ class TestEdfReader(unittest.TestCase):
         f.writePhysicalSamples(data)
         del f
 
-        try:
-            f = pyedflib.EdfReader(self.bdf_accented_file, pyedflib.READ_ALL_ANNOTATIONS, pyedflib.DO_NOT_CHECK_FILE_SIZE)
-        except IOError:
-            print('cannot open', self.bdf_accented_file)
-            np.testing.assert_raises(IOError,'cannot open file')
-            return
+        f = pyedflib.EdfReader(self.bdf_accented_file, pyedflib.READ_ALL_ANNOTATIONS, pyedflib.DO_NOT_CHECK_FILE_SIZE)
         np.testing.assert_equal(f.getTechnician(), 'tec1')
 
         np.testing.assert_equal(f.getLabel(0), 'test_label')

--- a/pyedflib/tests/test_edfreader.py
+++ b/pyedflib/tests/test_edfreader.py
@@ -153,33 +153,19 @@ class TestEdfReader(unittest.TestCase):
         del f
 
     def test_EdfReader_Close_file(self):
-        try:
-            f = pyedflib.EdfReader(self.edf_data_file)
-        except IOError:
-            print('cannot open', self.edf_data_file)
-            np.testing.assert_raises(IOError,'cannot open file')
-            return
+        f = pyedflib.EdfReader(self.edf_data_file)
         np.testing.assert_equal(f.getSignalLabels()[0], 'squarewave')
-        f._close()
-        f._close()
-        del f
-        try:
-            f = pyedflib.EdfReader(self.edf_data_file)
-        except IOError:
-            print('cannot open', self.edf_data_file)
-            np.testing.assert_raises(IOError,'cannot open file')
-            return
-        np.testing.assert_equal(f.getSignalLabels()[0], 'squarewave')
-        del f
 
-        try:
-            f = pyedflib.EdfReader(self.edf_data_file)
-        except IOError:
-            print('cannot open', self.edf_data_file)
-            np.testing.assert_raises(IOError,'cannot open file')
-            return
-        np.testing.assert_equal(f.getSignalLabels()[0], 'squarewave')
-        del f
+        # Don't close the file but try to reopen it and verify that it fails.
+        with np.testing.assert_raises(IOError):
+            ff = pyedflib.EdfReader(self.edf_data_file)
+        
+        # Now close and verify it can be re-opened/read.
+        f._close()
+
+        ff = pyedflib.EdfReader(self.edf_data_file)
+        np.testing.assert_equal(ff.getSignalLabels()[0], 'squarewave')
+        del f, ff
 
     def test_BdfReader_Read_accented_file(self):
         channel_info = {'label': 'test_label', 'dimension': 'mV', 'sample_rate': 100,


### PR DESCRIPTION
…se/verify expected behavior.

I'm a little bit confused by the intent of commit 330ca683fd6ffaf284dd5ad385d5a32cba4c7c10, but I did notice that assert_raises is invalid syntax and also seems to be a no-op in the except clauses. Hopefully this is a little better?