### PR TITLE
Add support for PEP 517 & 518

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+    "setuptools",
+    "wheel",
+    "numpy >= 1.9.1",
+    "cython"
+]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Include a `pyproject.toml` file with support for PEP 517 and 518. Without this support, pyEDFlib cannot be used within a project which follows PEP 517 and 518.