### PR TITLE
Reading of files with accented chars

### DIFF
--- a/pyedflib/_extensions/_pyedflib.pyx
+++ b/pyedflib/_extensions/_pyedflib.pyx
@@ -147,7 +147,7 @@ cdef class CyEdfReader:
         """
         open(file_name, annotations_mode, check_file_size)
         """
-        file_name_str = file_name.encode('raw_unicode_escape','strict')
+        file_name_str = file_name.encode('utf8','strict')
         result = c_edf.edfopen_file_readonly(file_name_str, &self.hdr, annotations_mode, check_file_size)
         
         self.file_name = file_name
@@ -455,7 +455,7 @@ def get_handle(file_number):
     return c_edf.edflib_get_handle(file_number)
 
 def is_file_used(path):
-    path_str = _ustring(path).encode('raw_unicode_escape','strict')
+    path_str = _ustring(path).encode('utf8','strict')
     return c_edf.edflib_is_file_used(path_str)
 
 # so you can use the same name if defining a python only function
@@ -464,7 +464,7 @@ def set_physical_maximum(handle, edfsignal, phys_max):
 
 def open_file_writeonly(path, filetype, number_of_signals):
     """int edfopen_file_writeonly(char *path, int filetype, int number_of_signals)"""
-    py_byte_string  = _ustring(path).encode('raw_unicode_escape','strict')
+    py_byte_string  = _ustring(path).encode('utf8','strict')
     cdef char* path_str = py_byte_string
     return c_edf.edfopen_file_writeonly(path_str, filetype, number_of_signals)
     

--- a/pyedflib/highlevel.py
+++ b/pyedflib/highlevel.py
@@ -316,8 +316,6 @@ def read_edf(edf_file, ch_nrs=None, ch_names=None, digital=False, verbose=True):
         the main header of the EDF file containing meta information.
 
     """
-    assert os.path.exists(edf_file.encode('utf8')), \
-            'file {} does not exist'.format(edf_file)
     assert (ch_nrs is  None) or (ch_names is None), \
            'names xor numbers should be supplied'
     if ch_nrs is not None and not isinstance(ch_nrs, list): ch_nrs = [ch_nrs]
@@ -632,7 +630,7 @@ def drop_channels(edf_source, edf_target=None, to_keep=None, to_drop=None):
     if to_drop is not None:
         assert all([isinstance(ch, (str, int)) for ch in to_drop]),\
             'channels must be int or string'
-    assert os.path.exists(edf_source.encode('utf8')), \
+    assert os.path.exists(edf_source), \
             'source file {} does not exist'.format(edf_source)
     assert edf_source!=edf_target, 'For safet, target must not be source file.'
         

--- a/pyedflib/highlevel.py
+++ b/pyedflib/highlevel.py
@@ -511,7 +511,7 @@ def read_edf_header(edf_file):
         annotations = f.read_annotation()
         annotations = [[t//10000000, d if d else -1, x] for t,d,x in annotations]
         summary = f.getHeader()
-        summary['Duration'] = f.getFileDuration
+        summary['Duration'] = f.getFileDuration()
         summary['SignalHeaders'] = f.getSignalHeaders()
         summary['channels'] = f.getSignalLabels()
         summary['annotations'] = annotations
@@ -543,10 +543,8 @@ def compare_edf(edf_file1, edf_file2, verbose=True):
     """
     if verbose: print('verifying data')
 
-    signals1, shead1, _ =  read_edf(edf_file1, digital=True, verbose=verbose,
-                                    return_list=True)
-    signals2, shead2, _ =  read_edf(edf_file2, digital=True, verbose=verbose,
-                                    return_list=True)
+    signals1, shead1, _ =  read_edf(edf_file1, digital=True, verbose=verbose)
+    signals2, shead2, _ =  read_edf(edf_file2, digital=True, verbose=verbose)
     
     for i, sigs in enumerate(zip(signals1, signals2)):
         s1, s2 = sigs

--- a/pyedflib/highlevel.py
+++ b/pyedflib/highlevel.py
@@ -38,7 +38,7 @@ def tqdm(iteratable, *args, **kwargs):
     if not installed this is just a pass through iterator
     """
     try:
-        from tqd3m import tqdm as iterator
+        from tqdm import tqdm as iterator
         return iterator(iteratable, *args, **kwargs)
     except:
         return iteratable
@@ -519,7 +519,7 @@ def read_edf_header(edf_file):
     return summary
 
 
-def compare_edf(edf_file1, edf_file2, verbose=True):
+def compare_edf(edf_file1, edf_file2):
     """
     Loads two edf files and checks whether the values contained in 
     them are the same. Does not check the header or annotations data.
@@ -541,10 +541,8 @@ def compare_edf(edf_file1, edf_file2, verbose=True):
     bool
         True if signals are equal, else raises error.
     """
-    if verbose: print('verifying data')
-
-    signals1, shead1, _ =  read_edf(edf_file1, digital=True, verbose=verbose)
-    signals2, shead2, _ =  read_edf(edf_file2, digital=True, verbose=verbose)
+    signals1, shead1, _ =  read_edf(edf_file1, digital=True)
+    signals2, shead2, _ =  read_edf(edf_file2, digital=True)
     
     for i, sigs in enumerate(zip(signals1, signals2)):
         s1, s2 = sigs

--- a/pyedflib/highlevel.py
+++ b/pyedflib/highlevel.py
@@ -316,7 +316,8 @@ def read_edf(edf_file, ch_nrs=None, ch_names=None, digital=False, verbose=True):
         the main header of the EDF file containing meta information.
 
     """
-    assert os.path.exists(edf_file), 'file {} does not exist'.format(edf_file)
+    assert os.path.exists(edf_file.encode('utf8')), \
+            'file {} does not exist'.format(edf_file)
     assert (ch_nrs is  None) or (ch_names is None), \
            'names xor numbers should be supplied'
     if ch_nrs is not None and not isinstance(ch_nrs, list): ch_nrs = [ch_nrs]
@@ -631,8 +632,8 @@ def drop_channels(edf_source, edf_target=None, to_keep=None, to_drop=None):
     if to_drop is not None:
         assert all([isinstance(ch, (str, int)) for ch in to_drop]),\
             'channels must be int or string'
-    assert os.path.exists(edf_source), 'source file {} does not exist'\
-                                       .format(edf_source)
+    assert os.path.exists(edf_source.encode('utf8')), \
+            'source file {} does not exist'.format(edf_source)
     assert edf_source!=edf_target, 'For safet, target must not be source file.'
         
     if edf_target is None: 

--- a/pyedflib/highlevel.py
+++ b/pyedflib/highlevel.py
@@ -693,26 +693,20 @@ def anonymize_edf(edf_file, new_file=None,
 
     assert len(to_remove)==len(new_values), \
            'Each to_remove must have one new_value'
-    header = read_edf_header(edf_file)
-    
-    for new_val, attr in zip(new_values, to_remove):
-        header[attr] = new_val
         
     if new_file is None:
         file, ext = os.path.splitext(edf_file)
         new_file = file + '_anonymized' + ext
-    n_chs = len(header['channels'])
-    signal_headers = []
-    signals = []
-    for ch_nr in tqdm(range(n_chs)):
-        signal, signal_header, _ = read_edf(edf_file, digital=True, 
-                                            ch_nrs=ch_nr, verbose=False)
-        signal_headers.append(signal_header[0])
-        signals.append(signal.squeeze())
+        
+    signals, signal_headers, header = read_edf(edf_file, digital=True)
+        
+    for new_val, attr in zip(new_values, to_remove):
+        header[attr] = new_val
+    
+    write_edf(new_file, signals, signal_headers, header, digital=True)
     if verify:
         compare_edf(edf_file, new_file)
-    return write_edf(new_file, signals, signal_headers, header, digital=True)
-
+    return True
 
 
 def rename_channels(edf_file, mapping, new_file=None):

--- a/pyedflib/highlevel.py
+++ b/pyedflib/highlevel.py
@@ -568,10 +568,6 @@ def compare_edf(edf_file1, edf_file2):
         s1 = dig2phys(s1, dmin1, dmax1, pmin1, pmax1)
         s2 = dig2phys(s2, dmin2, dmax2, pmin2, pmax2)
         
-        # now we can remove the signals from the list to save memory
-        signals1[i] = None
-        signals2[i] = None
-        
         # compare absolutes in case of inverted signals
         if np.array_equal(s1, s2): continue # early stopping
         s1 = np.abs(s1)

--- a/pyedflib/tests/test_edfreader.py
+++ b/pyedflib/tests/test_edfreader.py
@@ -18,7 +18,7 @@ class TestEdfReader(unittest.TestCase):
         self.edf_data_file = os.path.join(data_dir, 'test_generator.edf')
         self.bdf_broken_file = os.path.join(data_dir, 'tmp_broken_file.bdf')
         self.edf_broken_file = os.path.join(data_dir, 'tmp_broken_file.edf')
-        self.bdf_accented_file = os.path.join(data_dir, u'tmp_file_á.bdf')
+        self.bdf_accented_file = os.path.join(data_dir, u'tmp_file_áä\'üöß.bdf')
 
     def test_EdfReader(self):
         try:

--- a/pyedflib/tests/test_highlevel.py
+++ b/pyedflib/tests/test_highlevel.py
@@ -16,7 +16,7 @@ class TestHighLevel(unittest.TestCase):
         data_dir = os.path.join(os.path.dirname(__file__), 'data')
         self.edfplus_data_file = os.path.join(data_dir, 'tmp_test_file_plus.edf')
         self.test_generator = os.path.join(data_dir, 'test_generator.edf')
-
+        self.test_accented = os.path.join(data_dir, "test_áä'üöß.edf")
 
     def test_dig2phys_calc(self):
         signals_phys, shead, _ = highlevel.read_edf(self.test_generator)
@@ -133,6 +133,12 @@ class TestHighLevel(unittest.TestCase):
             highlevel.write_edf(self.edfplus_data_file, signals, sheaders, digital=False)
             
 
+    def test_read_write_accented(self):
+        signals = np.random.rand(3, 256*60)
+        highlevel.write_edf_quick(self.test_accented, signals, sfreq=256)
+        signals2, _, _ = highlevel.read_edf(self.test_accented)
+        
+        np.testing.assert_allclose(signals, signals2, atol=0.00002)
             
 if __name__ == '__main__':
     # run_module_suite(argv=sys.argv)

--- a/pyedflib/tests/test_highlevel.py
+++ b/pyedflib/tests/test_highlevel.py
@@ -16,7 +16,7 @@ class TestHighLevel(unittest.TestCase):
         data_dir = os.path.join(os.path.dirname(__file__), 'data')
         self.edfplus_data_file = os.path.join(data_dir, 'tmp_test_file_plus.edf')
         self.test_generator = os.path.join(data_dir, 'test_generator.edf')
-        self.test_accented = os.path.join(data_dir, "test_áä'üöß.edf")
+        self.test_accented = os.path.join(data_dir, u"test_áä'üöß.edf")
 
     def test_dig2phys_calc(self):
         signals_phys, shead, _ = highlevel.read_edf(self.test_generator)

--- a/pyedflib/tests/test_highlevel.py
+++ b/pyedflib/tests/test_highlevel.py
@@ -166,7 +166,7 @@ class TestHighLevel(unittest.TestCase):
                                                    'admincode', 'patientcode',
                                                    'technician'],
                                         new_values=['x', '', 'xx', 'xxx',
-                                                    'xxxx'])
+                                                    'xxxx'], verify=True)
         new_header = highlevel.read_edf_header(self.anonymized)
         self.assertEqual(new_header['birthdate'], '')
         self.assertEqual(new_header['patientname'], 'x')
@@ -180,7 +180,8 @@ class TestHighLevel(unittest.TestCase):
                                     to_remove=['patientname', 'birthdate',
                                                'admincode', 'patientcode',
                                                'technician'],
-                                    new_values=['x', '', 'xx', 'xxx'])
+                                    new_values=['x', '', 'xx', 'xxx'],
+                                    verify=True)
 
 
 


### PR DESCRIPTION
There seem to be persistent problems with accented characters on Linux and Windows.

The initial #21 was fixed, however it still poses a problem as seen in #30 and #57 . Additionally, I also have problems on my Windows machine with Umlauts.

I reverted the changes proposed in #21 and switched back to UTF8-encoding of files. It seems to work now.

@holgern If errors continue, we can revert this commit again.