### PR TITLE
Fix links and formatting of index.rst, start using sphinx.ext.viewcode

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -40,7 +40,7 @@ except TypeError:
 extensions = ['sphinx.ext.doctest', 'sphinx.ext.autodoc', 'sphinx.ext.todo',
               'sphinx.ext.extlinks', 'sphinx.ext.mathjax',
               'sphinx.ext.autosummary', 'numpydoc',
-              'sphinx.ext.intersphinx',
+              'sphinx.ext.intersphinx', 'sphinx.ext.viewcode',
               'matplotlib.sphinxext.plot_directive']
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,7 +1,7 @@
 PyEDFlib -EDF/BDF Toolbox in Python
-=================================================
+===================================
 
-PyEDFlib is a free Open Source wavelet toolbox for reading / writing EDF/BDF files. 
+PyEDFlib is a free Open Source wavelet toolbox for reading / writing *EDF/EDF+/BDF* files.
 
 
   .. sourcecode:: python
@@ -9,7 +9,7 @@ PyEDFlib is a free Open Source wavelet toolbox for reading / writing EDF/BDF fil
     import pyedflib
     import numpy as np
     import os
-    
+
     file_name = os.path.join(pyedflib.util.test_data_path(),
                              'test_generator.edf')
     f = pyedflib.EdfReader(file_name)
@@ -21,30 +21,28 @@ PyEDFlib is a free Open Source wavelet toolbox for reading / writing EDF/BDF fil
 
 
 Description
--------------
+-----------
 
-pyEDFlib is a python library to read/write EDF+/BDF+ files based on EDFlib.
+``PyEDFlib`` is a `Python`_ library to read/write *EDF/EDF+/BDF* files based on EDFlib.
 
-EDF means [European Data Format](http://www.edfplus.info/) and was firstly published [1992](http://www.sciencedirect.com/science/article/pii/0013469492900097). 
-In 2003, an improved version of the file protokoll named EDF+ has been published and can be found [here](http://www.sciencedirect.com/science/article/pii/0013469492900097).
+*EDF* stands for `European Data Format <http://www.edfplus.info/>`_, a data format for EEG data, first `published in 1992 <https://doi.org/10.1016/0013-4694(92)90009-7>`_.
+In 2003, an improved version of the file protocol named *EDF+* `has been published <https://doi.org/10.1016/S1388-2457(03)00123-8>`_.
 
-The EDF/EDF+ format saves all data with 16 Bit. A version which saves all data with 24 Bit,
-was introduces by the compony [BioSemi](http://www.biosemi.com/faq/file_format.htm).
+The definition of the *EDF/EDF+* format can be found under `edfplus.info <https://www.edfplus.info/>`_.
 
-The definition of the EDF/EDF+/BDF/BDF+ format can be found under [edfplus.info](http://www.edfplus.info/).
+The *EDF/EDF+* format saves all data with 16 Bit.
+A version of the format which saves all data with 24 Bit, called *BDF*, was introduced by the company `BioSemi <https://www.biosemi.com/faq/file_format.htm>`_.
 
-This python toolbox is a fork of the [toolbox from Christopher Lee-Messer](https://bitbucket.org/cleemesser/python-edf/)
-and uses the [EDFlib](http://www.teuniz.net/edflib/) from Teunis van Beelen.
-The EDFlib is able to read and write EDF/EDF+/BDF/BDF+ files.
-
+The ``PyEDFlib`` `Python`_ toolbox is a fork of the ``python-edf`` `toolbox from Christopher Lee-Messer <https://bitbucket.org/cleemesser/python-edf/>`_.
+and uses the `EDFlib <http://www.teuniz.net/edflib/>`_ from Teunis van Beelen.
 
 Requirements
 ------------
 
- It requires:
+``PyEDFlib`` requires:
 
- - Python_ >=3.5
- - Numpy_ >= 1.9.1
+- Python_ >=3.5
+- Numpy_ >= 1.9.1
 
 Download
 --------
@@ -52,11 +50,11 @@ Download
 The most recent *development* version can be found on GitHub at
 https://github.com/holgern/pyedflib.
 
-Latest release, including source and binary package for Windows, is available
+The latest release, including source and binary package for Windows, is available
 for download from the `Python Package Index`_ or on the `Releases Page`_.
 
 License
---------
+-------
 
 This code is licensed under the same BSD-style license that Teunis released `edflib`_ under and with the same disclaimer.
 


### PR DESCRIPTION
Hey @holgern,

thanks for this toolbox. I just went through to find whether it has what I need (anonymization of EDF files), and fixed some formatting issues on your docs website on the way.

Hope that it's helpful.

PS: the `sphinx.ext.viewcode` extension provides a nice "View code" link next to the API documentation, to allow users to directly jump to viewing the sourcecode. looks a bit like here: 

(see turqouise SOURCE link in this screenshot)

![image](https://user-images.githubusercontent.com/9084751/86531942-0383e900-bec6-11ea-984b-00d5390acafb.png)

try interactively here:

https://mne.tools/mne-bids/dev/generated/mne_bids.write_raw_bids.html#mne_bids.write_raw_bids