### PR TITLE
Assert that physical_min is different from physical_max

### DIFF
--- a/pyedflib/edfwriter.py
+++ b/pyedflib/edfwriter.py
@@ -667,6 +667,11 @@ class EdfWriter(object):
             if any([not np.issubdtype(a.dtype, np.integer) for a in data_list]):
                 raise TypeError('Digital = True requires all signals in int')
 
+        # Check that all channels have different physical_minimum and physical_maximum
+        for chan in self.channels:
+            assert chan['physical_min'] != chan['physical_max'], \
+            'In chan {} physical_min {} should be different from '\
+            'physical_max {}'.format(chan['label'], chan['physical_min'], chan['physical_max'])
 
         ind = []
         notAtEnd = True

--- a/pyedflib/highlevel.py
+++ b/pyedflib/highlevel.py
@@ -445,8 +445,6 @@ def write_edf(edf_file, signals, signal_headers, header=None, digital=False,
             assert dmax>=s.max(), \
             'digital_min is {}, but signal_min is {}' \
             'for channel {}'.format(dmax, s.max(), label)
-            assert pmin != pmax, \
-            'physical_min {} should be different from physical_max {}'.format(pmin,pmax)
         else: # only warning, as this will not lead to clipping
             assert pmin<=s.min(), \
             'phys_min is {}, but signal_min is {} ' \

--- a/pyedflib/highlevel.py
+++ b/pyedflib/highlevel.py
@@ -445,6 +445,8 @@ def write_edf(edf_file, signals, signal_headers, header=None, digital=False,
             assert dmax>=s.max(), \
             'digital_min is {}, but signal_min is {}' \
             'for channel {}'.format(dmax, s.max(), label)
+            assert pmin != pmax, \
+            'physical_min {} should be different from physical_max {}'.format(pmin,pmax)
         else: # only warning, as this will not lead to clipping
             assert pmin<=s.min(), \
             'phys_min is {}, but signal_min is {} ' \

--- a/pyedflib/tests/test_edfwriter.py
+++ b/pyedflib/tests/test_edfwriter.py
@@ -710,6 +710,26 @@ class TestEdfWriter(unittest.TestCase):
         np.testing.assert_almost_equal(ann_duration[2], 0)
         np.testing.assert_equal(ann_text[2], "abc")
 
+    def test_physical_range_inequality(self):
+        # Prepare data
+        channel_data1 = np.sin(np.arange(1,1001))
+        channel_info1 = {'label': 'test_label_sin', 'dimension': 'mV', 'sample_rate': 100,
+                        'physical_max': max(channel_data1), 'physical_min': min(channel_data1),
+                        'digital_max': 8388607, 'digital_min': -8388608,
+                        'prefilter': 'pre1', 'transducer': 'trans1'}
+
+        channel_data2 = np.zeros((1000,))
+        channel_info2 = {'label': 'test_label_zero', 'dimension': 'mV', 'sample_rate': 100,
+                            'physical_max': max(channel_data2), 'physical_min': min(channel_data2),
+                            'digital_max': 8388607, 'digital_min': -8388608,
+                            'prefilter': 'pre1', 'transducer': 'trans1'}
+        f = pyedflib.EdfWriter(self.edf_data_file, 2,
+                                file_type=pyedflib.FILETYPE_BDF)
+        f.setSignalHeader(0,channel_info1)
+        f.setSignalHeader(1,channel_info2)
+        
+        # Test that assertion fails
+        self.assertRaises(AssertionError, f.writeSamples, [channel_data1, channel_data2])
 
 if __name__ == '__main__':
     # run_module_suite(argv=sys.argv)


### PR DESCRIPTION
I've noticed that if physical_min and physical_max are equal, write_samples fails with error -25. An assertion before writing can help the user in understanding the issue