### PR TITLE
Automatically set blocksize // speed up writing

### DIFF
--- a/pyedflib/highlevel.py
+++ b/pyedflib/highlevel.py
@@ -406,6 +406,7 @@ def write_edf(edf_file, signals, signal_headers, header=None, digital=False,
         set the block size for writing. Should be divisor of signal length
         in seconds. Higher values mean faster writing speed, but if it
         is not a divisor of the signal duration, it will append zeros.
+        Can be any value between 1 and 60, -1 will auto-infer the best value.
 
     Returns
     -------
@@ -420,7 +421,7 @@ def write_edf(edf_file, signals, signal_headers, header=None, digital=False,
         'signals and signal_headers must be same length'
     assert file_type in [-1, 0, 1, 2, 3], \
         'filetype must be in range -1, 3'
-    assert block_size<=60 and block_size>=-1, \
+    assert block_size<=60 and block_size>=-1 and block_size!=0, \
         'blocksize must be smaller or equal to 60'
 
     # copy objects to prevent accidential changes to mutable objects
@@ -451,6 +452,10 @@ def write_edf(edf_file, signals, signal_headers, header=None, digital=False,
     if block_size == -1:
         signal_duration = len(signals[0]) // signal_headers[0]['sample_rate']
         block_size = max([d for d in range(1, 61) if signal_duration % d == 0])
+    else:
+        if signal_duration % block_size != 0:
+            warnings.warn('Signal length is not dividable by block_size. '+
+                          'The file will have a zeros appended.')
 
     # check dmin, dmax and pmin, pmax dont exceed signal min/max
     for sig, shead in zip(signals, signal_headers):

--- a/pyedflib/highlevel.py
+++ b/pyedflib/highlevel.py
@@ -377,7 +377,7 @@ def read_edf(edf_file, ch_nrs=None, ch_names=None, digital=False, verbose=True):
 
 
 def write_edf(edf_file, signals, signal_headers, header=None, digital=False,
-              file_type=-1, block_size=-1):
+              file_type=-1, block_size=1):
     """
     Write signals to an edf_file. Header can be generated on the fly with
     generic values. EDF+/BDF+ is selected based on the filename extension,
@@ -406,7 +406,7 @@ def write_edf(edf_file, signals, signal_headers, header=None, digital=False,
         set the block size for writing. Should be divisor of signal length
         in seconds. Higher values mean faster writing speed, but if it
         is not a divisor of the signal duration, it will append zeros.
-        Can be any value between 1 and 60, -1 will auto-infer the best value.
+        Can be any value between 1=><=60, -1 will auto-infer the fastest value.
 
     Returns
     -------

--- a/pyedflib/highlevel.py
+++ b/pyedflib/highlevel.py
@@ -449,11 +449,10 @@ def write_edf(edf_file, signals, signal_headers, header=None, digital=False,
     # block_size sets the size of each writing block and should be a divisor
     # of the length of the signal. If it is not, the remainder of the file
     # will be filled with zeros.
+    signal_duration = len(signals[0]) // signal_headers[0]['sample_rate']
     if block_size == -1:
-        signal_duration = len(signals[0]) // signal_headers[0]['sample_rate']
         block_size = max([d for d in range(1, 61) if signal_duration % d == 0])
-    else:
-        if signal_duration % block_size != 0:
+    elif signal_duration % block_size != 0:
             warnings.warn('Signal length is not dividable by block_size. '+
                           'The file will have a zeros appended.')
 

--- a/pyedflib/tests/test_highlevel.py
+++ b/pyedflib/tests/test_highlevel.py
@@ -56,7 +56,7 @@ class TestHighLevel(unittest.TestCase):
         
         header = highlevel.make_header(technician='tech', recording_additional='r_add',
                                                 patientname='name', patient_additional='p_add',
-                                                patientcode='42', equipment='eeg', admincode='420',
+                                                patientcode='42', equipment='eeg', admincode='120',
                                                 gender='Male', startdate=startdate,birthdate='05.09.1980')
         annotations = [[0.01, -1, 'begin'],[0.5, -1, 'middle'],[10, -1, 'end']]
 
@@ -249,6 +249,37 @@ class TestHighLevel(unittest.TestCase):
         
         with self.assertRaises(AssertionError):
             highlevel.drop_channels(self.drop_from, to_keep=['ch1'], to_drop=['ch3'])
+
+
+    def test_blocksize_auto(self):
+        """ test that the blocksize parameter works as intended"""
+        file = '{}.edf'.format(self.tmp_testfile)
+        siglen = 256* 155
+        signals = np.random.rand(10, siglen)
+        sheads = highlevel.make_signal_headers([str(x) for x in range(10)],
+                                              sample_rate=256, physical_max=1,
+                                              physical_min=-1)
+
+        valid_block_sizes = [-1, 1, 5, 31]
+        for block_size in valid_block_sizes:
+            highlevel.write_edf(file, signals, sheads, block_size=block_size)
+            signals2, _, _ = highlevel.read_edf(file)
+            np.testing.assert_allclose(signals, signals2, atol=0.01)
+
+        with self.assertRaises(AssertionError):
+            highlevel.write_edf(file, signals, sheads, block_size=61)
+
+        with self.assertRaises(AssertionError):
+            highlevel.write_edf(file, signals, sheads, block_size=-2)
+
+        # now test non-divisor block_size
+        siglen = signals.shape[-1]
+        highlevel.write_edf(file, signals, sheads, block_size=60)
+        signals2, _, _ = highlevel.read_edf(file)
+        self.assertEqual(signals2.shape, (10, 256*60*3))
+        np.testing.assert_allclose(signals2[:,:siglen], signals, atol=0.01)
+        np.testing.assert_allclose(signals2[:,siglen:], np.zeros([10, 25*256]),
+                                   atol=0.0001)
 
 
     # def test_rename_channels(self):


### PR DESCRIPTION
I've implemented automatic setting of the blocksize, it will default to the highest `int` divisor below 60. As far as I can see `datarecord_duration` is in fact a float and could be set to any value, however, I'm a bit afraid that this will introduce side effects and rounding errors that result in loss of samples.

I did not want to include a manual trim while loading, as other EDF loading software does not implement that. However, the `block_size` parameter can be set manually if people do not mind having padded zeros at the end.

related: #92 

@holgern can you check, approve and possibly make a new release?