### PR TITLE
adding unicode read/write tests + workaround windows unicode files

### DIFF
--- a/pyedflib/_extensions/_pyedflib.pyx
+++ b/pyedflib/_extensions/_pyedflib.pyx
@@ -534,9 +534,9 @@ def open_file_writeonly(path, filetype, number_of_signals):
         # Check if we're on Windows and the file path contains Unicode.
         # If so, use workaround to create file: In Python, create the file,
         # then look up and pass the short file name to the C library
-        if using_unicode:
+        if not using_unicode:
             warnings.warn('Attempting to write Unicode file {} on Windows. ' \
-                          'Consider chaning your locale to UTF8.'.format(path))
+                          'Consider changing your locale to UTF8.'.format(path))
             with open(path, 'wb'): pass
             path = get_short_path_name(path)
 

--- a/pyedflib/_extensions/_pyedflib.pyx
+++ b/pyedflib/_extensions/_pyedflib.pyx
@@ -19,6 +19,7 @@ __all__ = ['lib_version', 'CyEdfReader', 'set_patientcode', 'set_starttime_subse
 
 
 #from c_edf cimport *
+import locale
 import os
 import warnings
 cimport c_edf

--- a/pyedflib/_extensions/_pyedflib.pyx
+++ b/pyedflib/_extensions/_pyedflib.pyx
@@ -152,11 +152,11 @@ cdef class CyEdfReader:
             is_windows = os.name == 'nt'
             if exists and is_windows and contains_unicode(file_name):
                 # work-around to at least make Unicode files readable at all
-                file_name = get_short_path_name(file_name)
-                self.open(file_name, mode='r', annotations_mode=annotations_mode, check_file_size=check_file_size)
                 warnings.warn('the filename {} contains Unicode, but Windows does not fully support this. ' \
                               'Please consider changing your locale to support UTF8. Attempting to ' 
                               'load file via workaround (https://github.com/holgern/pyedflib/pull/100) '.format(file_name))
+                file_name = get_short_path_name(file_name)
+                self.open(file_name, mode='r', annotations_mode=annotations_mode, check_file_size=check_file_size)
             elif exists:
                 raise OSError('File {} was found but cant be accessed. ' \
                               'Make sure it contains no special characters ' \
@@ -522,10 +522,12 @@ def set_physical_maximum(handle, edfsignal, phys_max):
 def open_file_writeonly(path, filetype, number_of_signals):
     """int edfopen_file_writeonly(char *path, int filetype, int number_of_signals)"""
 
-    if os.name=='nt' and contains_unicode(path):
+    if os.name=='nt' and contains_unicode(path) and locale.getlocale()[1].lower()!='utf8':
         # Check if we're on Windows and the file path contains Unicode.
         # If so, use workaround to create file: In Python, create the file,
         # then look up and pass the short file name to the C library
+        warnings.warn('Attempting to write Unicode file {} on Windows. ' \
+                      'Consider chaning your locale to UTF8.'.format(path))
         with open(path, 'wb'): pass
         path = get_short_path_name(path)
 

--- a/pyedflib/_extensions/c/edflib.c
+++ b/pyedflib/_extensions/c/edflib.c
@@ -36,7 +36,8 @@
 
 /* compile with options "-D_LARGEFILE64_SOURCE -D_LARGEFILE_SOURCE" */
 
-
+#pragma warning( disable : 4996 ) // ignore unsafe strncpy
+#pragma warning( disable : 4244 ) // ignore precision loss
 
 #include "edflib.h"
 

--- a/pyedflib/tests/test_highlevel.py
+++ b/pyedflib/tests/test_highlevel.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2019 - 2020 Simon Kern
 # Copyright (c) 2015 Holger Nahrstaedt
 
-import os, sys
+import os, sys, shutil
 import numpy as np
 # from numpy.testing import (assert_raises, run_module_suite,
 #                            assert_equal, assert_allclose, assert_almost_equal)
@@ -20,6 +20,7 @@ class TestHighLevel(unittest.TestCase):
         cls.edfplus_data_file = os.path.join(data_dir, 'tmp_test_file_plus.edf')
         cls.test_generator = os.path.join(data_dir, 'test_generator.edf')
         cls.test_accented = os.path.join(data_dir, "tmp_áä'üöß.edf")
+        cls.test_unicode = os.path.join(data_dir, "tmp_utf8-中文źąşㆆ운ʷᨄⅡəПр🤖.edf")
         cls.anonymized = os.path.join(data_dir, "tmp_anonymized.edf")
         cls.personalized = os.path.join(data_dir, "tmp_personalized.edf")
         cls.drop_from = os.path.join(data_dir, 'tmp_drop_from.edf')
@@ -162,8 +163,16 @@ class TestHighLevel(unittest.TestCase):
         signals2, _, _ = highlevel.read_edf(self.test_accented)
         
         np.testing.assert_allclose(signals, signals2, atol=0.00002)
-            
-        
+        self.assertTrue(os.path.isfile(self.test_accented), 'File does not exist')
+
+    def test_read_unicode(self):
+        signals = np.random.rand(3, 256*60)
+        success = highlevel.write_edf_quick(self.edfplus_data_file, signals, sfreq=256)
+        self.assertTrue(success)
+        shutil.copy(self.edfplus_data_file, self.test_unicode)
+        signals2, _, _ = highlevel.read_edf(self.test_unicode)
+
+
     def test_read_header(self):
         
         header = highlevel.read_edf_header(self.test_generator)

--- a/pyedflib/tests/test_highlevel.py
+++ b/pyedflib/tests/test_highlevel.py
@@ -163,7 +163,8 @@ class TestHighLevel(unittest.TestCase):
         signals2, _, _ = highlevel.read_edf(self.test_accented)
         
         np.testing.assert_allclose(signals, signals2, atol=0.00002)
-        self.assertTrue(os.path.isfile(self.test_accented), 'File does not exist')
+        if os.name!='nt':
+            self.assertTrue(os.path.isfile(self.test_accented), 'File does not exist')
 
     def test_read_unicode(self):
         signals = np.random.rand(3, 256*60)

--- a/pyedflib/tests/test_highlevel.py
+++ b/pyedflib/tests/test_highlevel.py
@@ -163,8 +163,8 @@ class TestHighLevel(unittest.TestCase):
         signals2, _, _ = highlevel.read_edf(self.test_accented)
         
         np.testing.assert_allclose(signals, signals2, atol=0.00002)
-        if os.name!='nt':
-            self.assertTrue(os.path.isfile(self.test_accented), 'File does not exist')
+        # if os.name!='nt':
+        self.assertTrue(os.path.isfile(self.test_accented), 'File does not exist')
 
     def test_read_unicode(self):
         signals = np.random.rand(3, 256*60)
@@ -172,6 +172,7 @@ class TestHighLevel(unittest.TestCase):
         self.assertTrue(success)
         shutil.copy(self.edfplus_data_file, self.test_unicode)
         signals2, _, _ = highlevel.read_edf(self.test_unicode)
+        self.assertTrue(os.path.isfile(self.test_unicode), 'File does not exist')
 
 
     def test_read_header(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 requires = [
     "setuptools",
     "wheel",
+	"numpy <= 1.19.3",
     "cython"
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This PR adds workarounds on Windows systems that are not using UTF8. Unicode filenames and Windows are quite a pain, and do not interact well with each other, unless UTF8 encoding is set as a windows locale (available on Windows 10). The problem is that `edflib` uses `fopen` - which on Windows (unlike Unix) can only accept 7/8-bit ANSI filenames. There is a function `_wopen` for Windows that is able to use multibyte characters (= Unicode), but it is unavailable on other OSs, and therefore we would need to implement OS-specific handling of `fopen`, which might introduce unwanted side effects. This caveat has been discussed at many places, e.g. here: https://stackoverflow.com/questions/53240475/non-ascii-filename-for-fopen

I tried opening the file in Cython as a FILE pointer and passing that to `edflib` with no luck. I also tried to create a file descriptor in Python (which handles UTF8), and passing the file descriptor to `edflib` and replacing `fopen` with `fdopen`, but that also didn't seem to work, and would pose side-effects for some subfunctions.

Therefore I created a workaround for Windows:
Whenever a Unicode filename is used with `pyedflib` under Windows, the [short file name](https://stackoverflow.com/questions/23285759/fopen-file-name-with-utf8-string-in-windows) (DOS style) will be used to access the file.

This works straightforward on reading a file in almost all cases. When writing it is handled as follows: an empty file is created using Python (which handles Unicode filenames gracefully), as else no short-name can be infered. Then the short-name is looked up and used for writing to the specific file. All of this only happens if the file path is containing Unicode at all.

It is not very pretty, but it should work unless there are some administrative templates that prevent creation of 8.3-short path names. In these cases people need to find another work-around, e.g. renaming the file within Python before handling it.