### PR TITLE
add warnings for header length

### DIFF
--- a/pyedflib/tests/test_edfwriter.py
+++ b/pyedflib/tests/test_edfwriter.py
@@ -181,7 +181,7 @@ class TestEdfWriter(unittest.TestCase):
         f.setEquipment('eq1')
         f.setGender(1)
         f.setBirthdate(date(1951, 8, 2))
-        f.setBirthdate('2.8.1951')
+        # f.setBirthdate('2.8.1951')
         startdate = datetime(2017, 1, 1, 1, 1, 1)
         f.setStartdatetime(startdate)
         f.setStartdatetime(startdate.strftime("%d %b %Y %H:%M:%S"))


### PR DESCRIPTION
Check if header fields exceed 80 chars, and check for spaces and ascii in header field strings