### PR TITLE
Prevent fortran layout

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,8 +103,12 @@ Additionally functionality as anonymizing, dropping or renaming channels can be 
     highlevel.anonymize_edf('edf_file.edf', new_file='anonymized.edf'
 	                         to_remove=['patientname', 'birthdate'],
 	                         new_values=['anonymized', ''])
-	# check if the two files have the same content
-	highlevel.compare_edf('edf_file.edf', 'anonymized.edf')
+    # check if the two files have the same content
+    highlevel.compare_edf('edf_file.edf', 'anonymized.edf')
+    # change polarity of certain channels 
+    highlevel.change_polarity('file.edf', channels=[1,3])
+    # rename channels within a file
+    highlevel.rename_channels('file.edf', mapping={'C3-M1':'C3'})
 
 
 License

--- a/pyedflib/edfwriter.py
+++ b/pyedflib/edfwriter.py
@@ -692,7 +692,10 @@ class EdfWriter(object):
 
         if (len(data_list) != len(self.channels)):
             raise WrongInputSize(len(data_list))
-            
+
+        if any([np.isfortran(s) for s in data_list]) or np.isfortran(data_list):
+               warnings.warn('Members of data_list are in Fortran order. ' \
+                             'Please convert arrays to C order for best compatibility with edflib.')
         if digital:
             if any([not np.issubdtype(a.dtype, np.integer) for a in data_list]):
                 raise TypeError('Digital = True requires all signals in int')

--- a/pyedflib/edfwriter.py
+++ b/pyedflib/edfwriter.py
@@ -693,9 +693,10 @@ class EdfWriter(object):
         if (len(data_list) != len(self.channels)):
             raise WrongInputSize(len(data_list))
 
-        if any([np.isfortran(s) for s in data_list]) or np.isfortran(data_list):
-               warnings.warn('Members of data_list are in Fortran order. ' \
-                             'Please convert arrays to C order for best compatibility with edflib.')
+        if any([np.isfortran(s) for s in data_list if isinstance(s, np.ndarray)]) or \
+                (isinstance(data_list, np.ndarray) and np.isfortran(data_list)):
+           warnings.warn('signals are in Fortran order. Will automatically ' \
+                         'transfer to C order for compatibility with edflib.')
         if digital:
             if any([not np.issubdtype(a.dtype, np.integer) for a in data_list]):
                 raise TypeError('Digital = True requires all signals in int')

--- a/pyedflib/highlevel.py
+++ b/pyedflib/highlevel.py
@@ -482,6 +482,14 @@ def write_edf(edf_file, signals, signal_headers, header=None, digital=False,
     # get annotations, in format [[timepoint, duration, description], [...]]
     annotations = header.get('annotations', [])
 
+    if any([np.isfortran(s) for s in signals]) or np.isfortran(signals):
+           warnings.warn('signals are in Fortran order. Will automatically ' \
+                         'transfer to C order for compatibility with edflib.')
+    if isinstance(signals, list):
+        signals = [s.copy(order='C') if np.isfortran(s) else s for s in signals]
+    elif isinstance(signals, np.ndarray) and np.isfortran(signals):
+        signals = signals.copy(order='C')
+
     with pyedflib.EdfWriter(edf_file, n_channels=n_channels, file_type=file_type) as f:
         f.setDatarecordDuration(int(100000 * block_size))
         f.setSignalHeaders(signal_headers)

--- a/pyedflib/highlevel.py
+++ b/pyedflib/highlevel.py
@@ -482,7 +482,8 @@ def write_edf(edf_file, signals, signal_headers, header=None, digital=False,
     # get annotations, in format [[timepoint, duration, description], [...]]
     annotations = header.get('annotations', [])
 
-    if any([np.isfortran(s) for s in signals]) or np.isfortran(signals):
+    if any([np.isfortran(s) for s in signals]) or \
+        (isinstance(signals, np.ndarray) and np.isfortran(signals)):
            warnings.warn('signals are in Fortran order. Will automatically ' \
                          'transfer to C order for compatibility with edflib.')
     if isinstance(signals, list):


### PR DESCRIPTION
When arrays are either in Fortran order or of mixed order, the writing will take substantially longer. Therefore, a warning will be displayed if input arrays are in Fortran order. When using the highlevel interface to write, automatic convertion is applied.

See #92 and #105