### PR TITLE
Round sample rates up to 3 decimals not to int

### DIFF
--- a/pyedflib/edfreader.py
+++ b/pyedflib/edfreader.py
@@ -111,7 +111,7 @@ class EdfReader(CyEdfReader):
         """
         return {'label': self.getLabel(chn),
                 'dimension': self.getPhysicalDimension(chn),
-                                 'sample_rate': self.getSampleFrequency(chn),
+                'sample_rate': self.getSampleFrequency(chn),
                 'physical_max':self.getPhysicalMaximum(chn),
                 'physical_min': self.getPhysicalMinimum(chn),
                 'digital_max': self.getDigitalMaximum(chn),
@@ -388,7 +388,7 @@ class EdfReader(CyEdfReader):
 
         """
         if 0 <= chn < self.signals_in_file:
-            return round(self.samplefrequency(chn))
+            return np.round(self.samplefrequency(chn), decimals=3)
         else:
             return 0
 

--- a/pyedflib/highlevel.py
+++ b/pyedflib/highlevel.py
@@ -527,7 +527,7 @@ def write_edf_quick(edf_file, signals, sfreq, digital=False):
 
     """
     signals = np.atleast_2d(signals)
-    header = make_signal_header('ch_1', sample_rate=sfreq)
+    header = make_header(technician='pyedflib-quickwrite')
     labels = ['CH_{}'.format(i) for i in range(len(signals))]
     pmin, pmax = signals.min(), signals.max()
     signal_headers = make_signal_headers(labels, sample_rate = sfreq,

--- a/pyedflib/tests/test_edfwriter.py
+++ b/pyedflib/tests/test_edfwriter.py
@@ -766,6 +766,7 @@ class TestEdfWriter(unittest.TestCase):
             del f
 
 
+
 if __name__ == '__main__':
     # run_module_suite(argv=sys.argv)
     unittest.main()

--- a/pyedflib/tests/test_highlevel.py
+++ b/pyedflib/tests/test_highlevel.py
@@ -123,7 +123,26 @@ class TestHighLevel(unittest.TestCase):
         highlevel.write_edf_quick(self.edfplus_data_file, signals, sfreq=256)
         signals2, _, _ = highlevel.read_edf(self.edfplus_data_file)
         np.testing.assert_allclose(signals, signals2, atol=0.00002)
-        
+
+
+    def test_read_write_decimal_sample_rates(self):
+        signals = np.random.randint(-2048, 2048, [3, 256*60])
+        highlevel.write_edf_quick(self.edfplus_data_file, signals.astype(np.int32), sfreq=8.5, digital=True)
+        signals2, _, _ = highlevel.read_edf(self.edfplus_data_file, digital=True, verbose=True)
+        np.testing.assert_allclose(signals, signals2)
+        signals = np.random.rand(3, 256*60)
+        highlevel.write_edf_quick(self.edfplus_data_file, signals, sfreq=8.5, digital=False)
+        signals2, _, _ = highlevel.read_edf(self.edfplus_data_file, digital=False, verbose=True)
+        np.testing.assert_allclose(signals, signals2, atol=0.0001)
+
+    # def test_read_write_decimal_sample_rates_smaller_one(self):
+    #     signals = np.random.randint(-2048, 2048, [3, 256*60])
+    #     highlevel.write_edf_quick(self.edfplus_data_file, signals.astype(np.int32), sfreq=1/3, digital=True)
+    #     signals2, _, _ = highlevel.read_edf(self.edfplus_data_file, digital=True, verbose=True)
+    #     np.testing.assert_allclose(signals, signals2)
+
+
+
     def test_read_write_diff_sfreq(self):
         
         signals = []


### PR DESCRIPTION
Currently while reading EDF files sample rates were rounded to int. We should allow decimal sample rates while also preventing float-rounding-errors of sample rates like 199.9999. I assume rounding to three decimals should be sufficient.

closes #109 