### PR TITLE
Fix sample frequencies for record duration != 1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,13 +90,13 @@ Additionally functionality as anonymizing, dropping or renaming channels can be 
     # write an edf file
     signals = np.random.rand(5, 256*300)*200 # 5 minutes of random signal
     channel_names = ['ch1', 'ch2', 'ch3', 'ch4', 'ch5']
-    signal_headers = highlevel.make_signal_headers(channel_names, sample_rate=256)
+    signal_headers = highlevel.make_signal_headers(channel_names, sample_frequency=256)
     header = highlevel.make_header(patientname='patient_x', gender='Female')
     highlevel.write_edf('edf_file.edf', signals, signal_headers, header)
-	    
+
     # read an edf file
     signals, signal_headers, header = highlevel.read_edf('edf_file.edf')
-    print(signal_headers[0]['sample_rate']) # prints 256
+    print(signal_headers[0]['sample_frequency']) # prints 256
 
     # drop a channel from the file or anonymize edf
     highlevel.drop_channels('edf_file.edf', to_drop=['ch2', 'ch4'])

--- a/demo/writeEDFFile.py
+++ b/demo/writeEDFFile.py
@@ -32,7 +32,7 @@ if __name__ == '__main__':
     channel_info = []
     data_list = []
 
-    ch_dict = {'label': 'squarewave', 'dimension': 'uV', 'sample_rate': 200, 'physical_max': 100, 'physical_min': -100, 'digital_max': 32767, 'digital_min': -32768, 'transducer': '', 'prefilter':''}
+    ch_dict = {'label': 'squarewave', 'dimension': 'uV', 'sample_frequency': 200, 'physical_max': 100, 'physical_min': -100, 'digital_max': 32767, 'digital_min': -32768, 'transducer': '', 'prefilter':''}
     channel_info.append(ch_dict)
     time = np.linspace(0, file_duration, file_duration*200)
     xtemp = np.sin(2*np.pi*0.1*time)
@@ -41,13 +41,13 @@ if __name__ == '__main__':
     x1[np.where(xtemp < 0)[0]] = -100
     data_list.append(x1)
 
-    ch_dict = {'label': 'ramp', 'dimension': 'uV', 'sample_rate': 200, 'physical_max': 100, 'physical_min': -100, 'digital_max': 32767, 'digital_min': -32768, 'transducer': '', 'prefilter':''}
+    ch_dict = {'label': 'ramp', 'dimension': 'uV', 'sample_frequency': 200, 'physical_max': 100, 'physical_min': -100, 'digital_max': 32767, 'digital_min': -32768, 'transducer': '', 'prefilter':''}
     channel_info.append(ch_dict)
     time = np.linspace(0, file_duration, file_duration*200)
     x2 = signal.sawtooth(2 * np.pi * 1 * time)
     data_list.append(x2)
 
-    ch_dict = {'label': 'pulse 1', 'dimension': 'uV', 'sample_rate': 200, 'physical_max': 100, 'physical_min': -100, 'digital_max': 32767, 'digital_min': -32768, 'transducer': '', 'prefilter':''}
+    ch_dict = {'label': 'pulse 1', 'dimension': 'uV', 'sample_frequency': 200, 'physical_max': 100, 'physical_min': -100, 'digital_max': 32767, 'digital_min': -32768, 'transducer': '', 'prefilter':''}
     channel_info.append(ch_dict)
     time = np.linspace(0, file_duration, file_duration*200)
     xtemp = np.sin(2*np.pi*0.5*time)
@@ -55,7 +55,7 @@ if __name__ == '__main__':
     x3[np.where(np.all((xtemp < 0.02, xtemp > -0.02),axis=0))[0]] = 100
     data_list.append(x3)
 
-    ch_dict = {'label': 'pulse 2', 'dimension': 'uV', 'sample_rate': 256, 'physical_max': 100, 'physical_min': -100, 'digital_max': 32767, 'digital_min': -32768, 'transducer': '', 'prefilter':''}
+    ch_dict = {'label': 'pulse 2', 'dimension': 'uV', 'sample_frequency': 256, 'physical_max': 100, 'physical_min': -100, 'digital_max': 32767, 'digital_min': -32768, 'transducer': '', 'prefilter':''}
     channel_info.append(ch_dict)
     time = np.linspace(0, file_duration, file_duration*256)
     xtemp = np.sin(2*np.pi*0.5*time)
@@ -63,7 +63,7 @@ if __name__ == '__main__':
     x4[np.where(np.all((xtemp < 0.02, xtemp > -0.02),axis=0))[0]] = 100
     data_list.append(x4)
 
-    ch_dict = {'label': 'pulse 3', 'dimension': 'uV', 'sample_rate': 217, 'physical_max': 100, 'physical_min': -100, 'digital_max': 32767, 'digital_min': -32768, 'transducer': '', 'prefilter':''}
+    ch_dict = {'label': 'pulse 3', 'dimension': 'uV', 'sample_frequency': 217, 'physical_max': 100, 'physical_min': -100, 'digital_max': 32767, 'digital_min': -32768, 'transducer': '', 'prefilter':''}
     channel_info.append(ch_dict)
     time = np.linspace(0, file_duration, file_duration*217)
     xtemp = np.sin(2*np.pi*0.5*time)
@@ -71,41 +71,41 @@ if __name__ == '__main__':
     x5[np.where(np.all((xtemp < 0.02, xtemp > -0.02),axis=0))[0]] = 100
     data_list.append(x5)
 
-    ch_dict = {'label': 'noise', 'dimension': 'uV', 'sample_rate': 200, 'physical_max': 100, 'physical_min': -100, 'digital_max': 32767, 'digital_min': -32768, 'transducer': '', 'prefilter':''}
+    ch_dict = {'label': 'noise', 'dimension': 'uV', 'sample_frequency': 200, 'physical_max': 100, 'physical_min': -100, 'digital_max': 32767, 'digital_min': -32768, 'transducer': '', 'prefilter':''}
     channel_info.append(ch_dict)
     data_list.append(np.random.normal(size=file_duration*200))
 
-    ch_dict = {'label': 'sine 1 Hz', 'dimension': 'uV', 'sample_rate': 200, 'physical_max': 100, 'physical_min': -100, 'digital_max': 32767, 'digital_min': -32768, 'transducer': '', 'prefilter':''}
+    ch_dict = {'label': 'sine 1 Hz', 'dimension': 'uV', 'sample_frequency': 200, 'physical_max': 100, 'physical_min': -100, 'digital_max': 32767, 'digital_min': -32768, 'transducer': '', 'prefilter':''}
     channel_info.append(ch_dict)
     time = np.linspace(0, file_duration, file_duration*200)
     data_list.append(np.sin(2*np.pi*1*time))
 
-    ch_dict = {'label': 'sine 8 Hz', 'dimension': 'uV', 'sample_rate': 200, 'physical_max': 100, 'physical_min': -100, 'digital_max': 32767, 'digital_min': -32768, 'transducer': '', 'prefilter':''}
+    ch_dict = {'label': 'sine 8 Hz', 'dimension': 'uV', 'sample_frequency': 200, 'physical_max': 100, 'physical_min': -100, 'digital_max': 32767, 'digital_min': -32768, 'transducer': '', 'prefilter':''}
     channel_info.append(ch_dict)
     time = np.linspace(0, file_duration, file_duration*200)
     data_list.append(np.sin(2*np.pi*8*time))
 
-    ch_dict = {'label': 'sine 8.1777 Hz', 'dimension': 'uV', 'sample_rate': 200, 'physical_max': 100, 'physical_min': -100, 'digital_max': 32767, 'digital_min': -32768, 'transducer': '', 'prefilter':''}
+    ch_dict = {'label': 'sine 8.1777 Hz', 'dimension': 'uV', 'sample_frequency': 200, 'physical_max': 100, 'physical_min': -100, 'digital_max': 32767, 'digital_min': -32768, 'transducer': '', 'prefilter':''}
     channel_info.append(ch_dict)
     time = np.linspace(0, file_duration, file_duration*200)
     data_list.append(np.sin(2*np.pi*8.1777*time))
 
-    ch_dict = {'label': 'sine 8.5 Hz', 'dimension': 'uV', 'sample_rate': 200, 'physical_max': 100, 'physical_min': -100, 'digital_max': 32767, 'digital_min': -32768, 'transducer': '', 'prefilter':''}
+    ch_dict = {'label': 'sine 8.5 Hz', 'dimension': 'uV', 'sample_frequency': 200, 'physical_max': 100, 'physical_min': -100, 'digital_max': 32767, 'digital_min': -32768, 'transducer': '', 'prefilter':''}
     channel_info.append(ch_dict)
     time = np.linspace(0, file_duration, file_duration*200)
     data_list.append(np.sin(2*np.pi*8.5*time))
 
-    ch_dict = {'label': 'sine 15 Hz', 'dimension': 'uV', 'sample_rate': 200, 'physical_max': 100, 'physical_min': -100, 'digital_max': 32767, 'digital_min': -32768, 'transducer': '', 'prefilter':''}
+    ch_dict = {'label': 'sine 15 Hz', 'dimension': 'uV', 'sample_frequency': 200, 'physical_max': 100, 'physical_min': -100, 'digital_max': 32767, 'digital_min': -32768, 'transducer': '', 'prefilter':''}
     channel_info.append(ch_dict)
     time = np.linspace(0, file_duration, file_duration*200)
     data_list.append(np.sin(2*np.pi*15*time))
 
-    ch_dict = {'label': 'sine 17 Hz', 'dimension': 'uV', 'sample_rate': 200, 'physical_max': 100, 'physical_min': -100, 'digital_max': 32767, 'digital_min': -32768, 'transducer': '', 'prefilter':''}
+    ch_dict = {'label': 'sine 17 Hz', 'dimension': 'uV', 'sample_frequency': 200, 'physical_max': 100, 'physical_min': -100, 'digital_max': 32767, 'digital_min': -32768, 'transducer': '', 'prefilter':''}
     channel_info.append(ch_dict)
     time = np.linspace(0, file_duration, file_duration*200)
     data_list.append(np.sin(2*np.pi*17*time))
 
-    ch_dict = {'label': 'sine 50 Hz', 'dimension': 'uV', 'sample_rate': 200, 'physical_max': 100, 'physical_min': -100, 'digital_max': 32767, 'digital_min': -32768, 'transducer': '', 'prefilter':''}
+    ch_dict = {'label': 'sine 50 Hz', 'dimension': 'uV', 'sample_frequency': 200, 'physical_max': 100, 'physical_min': -100, 'digital_max': 32767, 'digital_min': -32768, 'transducer': '', 'prefilter':''}
     channel_info.append(ch_dict)
     time = np.linspace(0, file_duration, file_duration*200)
     data_list.append(np.sin(2*np.pi*50*time))

--- a/pyedflib/_extensions/_pyedflib.pyx
+++ b/pyedflib/_extensions/_pyedflib.pyx
@@ -353,7 +353,7 @@ cdef class CyEdfReader:
 
     def samplefrequency(self, channel):
         try:
-            return (<double>self.hdr.signalparam[channel].smp_in_datarecord / self.hdr.datarecord_duration) * EDFLIB_TIME_DIMENSION
+            return <double>self.hdr.signalparam[channel].smp_in_datarecord
         except:
             return 0
     # def _tryoffset0(self):

--- a/pyedflib/edfreader.py
+++ b/pyedflib/edfreader.py
@@ -152,7 +152,7 @@ class EdfReader(CyEdfReader):
         """
         return {'label': self.getLabel(chn),
                 'dimension': self.getPhysicalDimension(chn),
-                'sample_rate': self.getSampleFrequency(chn),
+                'sample_frequency': self.getSampleFrequency(chn),
                 'physical_max':self.getPhysicalMaximum(chn),
                 'physical_min': self.getPhysicalMinimum(chn),
                 'digital_max': self.getDigitalMaximum(chn),

--- a/pyedflib/edfreader.py
+++ b/pyedflib/edfreader.py
@@ -152,6 +152,7 @@ class EdfReader(CyEdfReader):
         """
         return {'label': self.getLabel(chn),
                 'dimension': self.getPhysicalDimension(chn),
+                'sample_rate': self.getSampleFrequency(chn),
                 'sample_frequency': self.getSampleFrequency(chn),
                 'physical_max':self.getPhysicalMaximum(chn),
                 'physical_min': self.getPhysicalMinimum(chn),

--- a/pyedflib/edfwriter.py
+++ b/pyedflib/edfwriter.py
@@ -723,15 +723,11 @@ class EdfWriter(object):
         dataRecord = np.array([], dtype=np.int32 if digital else None)
 
         while notAtEnd:
-            # dataOfOneSecondInd = 0
             del dataRecord
             dataRecord = np.array([], dtype=np.int32 if digital else None)
             for i in np.arange(len(data_list)):
-                # dataOfOneSecond[dataOfOneSecondInd:dataOfOneSecondInd+self.channels[i]['sample_rate']] = data_list[i].ravel()[int(ind[i]):int(ind[i]+self.channels[i]['sample_rate'])]
                 dataRecord = np.append(dataRecord,data_list[i].ravel()[int(ind[i]):int(ind[i]+sampleFrequencies[i])])
-                # self.writePhysicalSamples(data_list[i].ravel()[int(ind[i]):int(ind[i]+self.channels[i]['sample_rate'])])
                 ind[i] += sampleFrequencies[i]
-                # dataOfOneSecondInd += sampleRates[i]
             if digital:
                 success = self.blockWriteDigitalSamples(dataRecord)
             else:
@@ -745,15 +741,12 @@ class EdfWriter(object):
                     notAtEnd = False
 
 
-        # dataOfOneSecondInd = 0
         for i in np.arange(len(data_list)):
             lastSamples = np.zeros(sampleFrequencies[i], dtype=np.int32 if digital else None)
             lastSampleInd = int(np.max(data_list[i].shape) - ind[i])
             lastSampleInd = int(np.min((lastSampleInd,sampleFrequencies[i])))
             if lastSampleInd > 0:
                 lastSamples[:lastSampleInd] = data_list[i].ravel()[-lastSampleInd:]
-                # dataOfOneSecond[dataOfOneSecondInd:dataOfOneSecondInd+self.channels[i]['sample_rate']] = lastSamples
-                # dataOfOneSecondInd += self.channels[i]['sample_rate']
                 if digital:
                     success = self.writeDigitalSamples(lastSamples)
                 else:
@@ -761,7 +754,6 @@ class EdfWriter(object):
 
                 if success<0:
                     raise IOError('Unknown error while calling writeSamples')
-        # self.blockWritePhysicalSamples(dataOfOneSecond)
 
     def writeAnnotation(self, onset_in_seconds, duration_in_seconds, description, str_format='utf-8'):
         """

--- a/pyedflib/highlevel.py
+++ b/pyedflib/highlevel.py
@@ -193,7 +193,7 @@ def make_header(technician='', recording_additional='', patientname='',
     return header
 
 
-def make_signal_header(label, dimension='uV', sample_rate=256,
+def make_signal_header(label, dimension='uV', sample_frequency=256,
                        physical_min=-200, physical_max=200, digital_min=-32768,
                        digital_max=32767, transducer='', prefiler=''):
     """
@@ -208,7 +208,7 @@ def make_signal_header(label, dimension='uV', sample_rate=256,
         the name of the channel.
     dimension : str, optional
         dimension, eg mV. The default is 'uV'.
-    sample_rate : int, optional
+    sample_frequency : int, optional
         sampling frequency. The default is 256.
     physical_min : float, optional
         minimum value in dimension. The default is -200.
@@ -232,7 +232,7 @@ def make_signal_header(label, dimension='uV', sample_rate=256,
 
     signal_header = {'label': label,
                'dimension': dimension,
-               'sample_rate': sample_rate,
+               'sample_frequency': sample_frequency,
                'physical_min': physical_min,
                'physical_max': physical_max,
                'digital_min':  digital_min,
@@ -242,7 +242,7 @@ def make_signal_header(label, dimension='uV', sample_rate=256,
     return signal_header
 
 
-def make_signal_headers(list_of_labels, dimension='uV', sample_rate=256,
+def make_signal_headers(list_of_labels, dimension='uV', sample_frequency=256,
                        physical_min=-200.0, physical_max=200.0,
                        digital_min=-32768, digital_max=32767,
                        transducer='', prefiler=''):
@@ -256,7 +256,7 @@ def make_signal_headers(list_of_labels, dimension='uV', sample_rate=256,
         A list with labels for each channel.
     dimension : str, optional
         dimension, eg mV. The default is 'uV'.
-    sample_rate : int, optional
+    sample_frequency : int, optional
         sampling frequency. The default is 256.
     physical_min : float, optional
         minimum value in dimension. The default is -200.
@@ -279,7 +279,7 @@ def make_signal_headers(list_of_labels, dimension='uV', sample_rate=256,
     """
     signal_headers = []
     for label in list_of_labels:
-        header = make_signal_header(label, dimension=dimension, sample_rate=sample_rate,
+        header = make_signal_header(label, dimension=dimension, sample_frequency=sample_frequency,
                                     physical_min=physical_min, physical_max=physical_max,
                                     digital_min=digital_min, digital_max=digital_max,
                                     transducer=transducer, prefiler=prefiler)
@@ -364,7 +364,7 @@ def read_edf(edf_file, ch_nrs=None, ch_names=None, digital=False, verbose=False)
             signals.append(signal)
 
         # we can only return a np.array if all signals have the same samplefreq
-        sfreqs = [shead['sample_rate'] for shead in signal_headers]
+        sfreqs = [shead['sample_frequency'] for shead in signal_headers]
         all_sfreq_same = sfreqs[1:]==sfreqs[:-1]
         if all_sfreq_same:
             dtype = np.int32 if digital else np.float
@@ -449,7 +449,7 @@ def write_edf(edf_file, signals, signal_headers, header=None, digital=False,
     # block_size sets the size of each writing block and should be a divisor
     # of the length of the signal. If it is not, the remainder of the file
     # will be filled with zeros.
-    signal_duration = len(signals[0]) // signal_headers[0]['sample_rate']
+    signal_duration = len(signals[0]) // signal_headers[0]['sample_frequency']
     if block_size == -1:
         block_size = max([d for d in range(1, 61) if signal_duration % d == 0])
     elif signal_duration % block_size != 0:
@@ -477,7 +477,7 @@ def write_edf(edf_file, signals, signal_headers, header=None, digital=False,
             assert pmax>=sig.max(), \
             'phys_max is {}, but signal_max is {} ' \
             'for channel {}'.format(pmax, sig.max(), label)
-        shead['sample_rate'] *= block_size
+        shead['sample_frequency'] *= block_size
 
     # get annotations, in format [[timepoint, duration, description], [...]]
     annotations = header.get('annotations', [])
@@ -530,7 +530,7 @@ def write_edf_quick(edf_file, signals, sfreq, digital=False):
     header = make_header(technician='pyedflib-quickwrite')
     labels = ['CH_{}'.format(i) for i in range(len(signals))]
     pmin, pmax = signals.min(), signals.max()
-    signal_headers = make_signal_headers(labels, sample_rate = sfreq,
+    signal_headers = make_signal_headers(labels, sample_frequency = sfreq,
                                          physical_min=pmin, physical_max=pmax)
     return write_edf(edf_file, signals, signal_headers, header, digital=digital)
 

--- a/pyedflib/tests/test_edfreader.py
+++ b/pyedflib/tests/test_edfreader.py
@@ -143,7 +143,7 @@ class TestEdfReader(unittest.TestCase):
         del f
 
     def test_EdfReader_Check_Size(self):
-        channel_info = {'label': 'test_label', 'dimension': 'mV', 'sample_rate': 100,
+        channel_info = {'label': 'test_label', 'dimension': 'mV', 'sample_frequency': 100,
                         'physical_max': 1.0, 'physical_min': -1.0,
                         'digital_max': 8388607, 'digital_min': -8388608,
                         'prefilter': 'pre1', 'transducer': 'trans1'}
@@ -183,7 +183,7 @@ class TestEdfReader(unittest.TestCase):
         del f, ff
 
     def test_BdfReader_Read_accented_file(self):
-        channel_info = {'label': 'test_label', 'dimension': 'mV', 'sample_rate': 100,
+        channel_info = {'label': 'test_label', 'dimension': 'mV', 'sample_frequency': 100,
                         'physical_max': 1.0, 'physical_min': -1.0,
                         'digital_max': 8388607, 'digital_min': -8388608,
                         'prefilter': 'pre1', 'transducer': 'trans1'}

--- a/pyedflib/tests/test_edfreader.py
+++ b/pyedflib/tests/test_edfreader.py
@@ -143,8 +143,9 @@ class TestEdfReader(unittest.TestCase):
         del f
 
     def test_EdfReader_Check_Size(self):
-        channel_info = {'label': 'test_label', 'dimension': 'mV', 'sample_frequency': 100,
-                        'physical_max': 1.0, 'physical_min': -1.0,
+        sample_frequency = 100
+        channel_info = {'label': 'test_label', 'dimension': 'mV', 'sample_rate': 256,
+                        'sample_frequency': sample_frequency, 'physical_max': 1.0, 'physical_min': -1.0,
                         'digital_max': 8388607, 'digital_min': -8388608,
                         'prefilter': 'pre1', 'transducer': 'trans1'}
         f = pyedflib.EdfWriter(self.bdf_broken_file, 1,file_type=pyedflib.FILETYPE_BDFPLUS)
@@ -162,9 +163,14 @@ class TestEdfReader(unittest.TestCase):
         np.testing.assert_equal(f.getPhysicalDimension(0), 'mV')
         np.testing.assert_equal(f.getPrefilter(0), 'pre1')
         np.testing.assert_equal(f.getTransducer(0), 'trans1')
-        np.testing.assert_equal(f.getSampleFrequency(0), 100)
-        np.testing.assert_equal(f.getSignalHeader(0), channel_info)
-        np.testing.assert_equal(f.getSignalHeaders(), [channel_info])
+        np.testing.assert_equal(f.getSampleFrequency(0), sample_frequency)
+
+        # When both 'sample_rate' and 'sample_frequency' are present, we write
+        # the file using the latter, which means that when we read it back,
+        # only the 'sample_frequency' value is present.
+        expected_signal_header = {**channel_info, 'sample_rate': sample_frequency}
+        np.testing.assert_equal(f.getSignalHeader(0), expected_signal_header)
+        np.testing.assert_equal(f.getSignalHeaders(), [expected_signal_header])
         del f
 
     def test_EdfReader_Close_file(self):
@@ -183,8 +189,9 @@ class TestEdfReader(unittest.TestCase):
         del f, ff
 
     def test_BdfReader_Read_accented_file(self):
-        channel_info = {'label': 'test_label', 'dimension': 'mV', 'sample_frequency': 100,
-                        'physical_max': 1.0, 'physical_min': -1.0,
+        sample_frequency = 100
+        channel_info = {'label': 'test_label', 'dimension': 'mV', 'sample_rate': 256,
+                        'sample_frequency': sample_frequency, 'physical_max': 1.0, 'physical_min': -1.0,
                         'digital_max': 8388607, 'digital_min': -8388608,
                         'prefilter': 'pre1', 'transducer': 'trans1'}
         f = pyedflib.EdfWriter(self.bdf_accented_file, 1,file_type=pyedflib.FILETYPE_BDFPLUS)
@@ -197,14 +204,17 @@ class TestEdfReader(unittest.TestCase):
 
         f = pyedflib.EdfReader(self.bdf_accented_file, pyedflib.READ_ALL_ANNOTATIONS, pyedflib.DO_NOT_CHECK_FILE_SIZE)
         np.testing.assert_equal(f.getTechnician(), 'tec1')
-
         np.testing.assert_equal(f.getLabel(0), 'test_label')
         np.testing.assert_equal(f.getPhysicalDimension(0), 'mV')
         np.testing.assert_equal(f.getPrefilter(0), 'pre1')
         np.testing.assert_equal(f.getTransducer(0), 'trans1')
-        np.testing.assert_equal(f.getSampleFrequency(0), 100)
-        np.testing.assert_equal(f.getSignalHeader(0), channel_info)
-        np.testing.assert_equal(f.getSignalHeaders(), [channel_info])
+
+        # When both 'sample_rate' and 'sample_frequency' are present, we write
+        # the file using the latter, which means that when we read it back,
+        # only the 'sample_frequency' value is present.
+        expected_signal_header = {**channel_info, 'sample_rate': sample_frequency}
+        np.testing.assert_equal(f.getSignalHeader(0), expected_signal_header)
+        np.testing.assert_equal(f.getSignalHeaders(), [expected_signal_header])
         del f
 
 if __name__ == '__main__':

--- a/pyedflib/tests/test_edfwriter.py
+++ b/pyedflib/tests/test_edfwriter.py
@@ -33,11 +33,11 @@ class TestEdfWriter(unittest.TestCase):
                 print(e)
 
     def test_write_functions(self):
-        channel_info1 = {'label': 'label1', 'dimension': 'mV', 'sample_rate': 100,
+        channel_info1 = {'label': 'label1', 'dimension': 'mV', 'sample_frequency': 100,
                         'physical_max': 32767, 'physical_min': -32768,
                         'digital_max': 32767, 'digital_min': -32768,
                         'prefilter': 'pre1', 'transducer': 'trans1'}
-        channel_info2 = {'label': 'label2', 'dimension': 'mV', 'sample_rate': 100,
+        channel_info2 = {'label': 'label2', 'dimension': 'mV', 'sample_frequency': 100,
                               'physical_max': 32767, 'physical_min': -32768,
                             'digital_max': 32767, 'digital_min': -32768,
                             'prefilter': 'pre1', 'transducer': 'trans1'}
@@ -101,7 +101,7 @@ class TestEdfWriter(unittest.TestCase):
         f = pyedflib.EdfWriter(self.edfplus_data_file, 1,
                                 file_type=pyedflib.FILETYPE_EDFPLUS)
 
-        channel_info = {'label': 'test_label', 'dimension': 'mV', 'sample_rate': 100,
+        channel_info = {'label': 'test_label', 'dimension': 'mV', 'sample_frequency': 100,
                         'physical_max': 1.0, 'physical_min': -1.0,
                         'digital_max': 32767, 'digital_min': -32768,
                         'prefilter': 'pre1', 'transducer': 'trans1'}
@@ -124,7 +124,7 @@ class TestEdfWriter(unittest.TestCase):
 
 
     def test_subsecond_annotation(self):
-        channel_info = {'label': 'test_label', 'dimension': 'mV', 'sample_rate': 100,
+        channel_info = {'label': 'test_label', 'dimension': 'mV', 'sample_frequency': 100,
                         'physical_max': 1.0, 'physical_min': -1.0,
                         'digital_max': 8388607, 'digital_min': -8388608,
                         'prefilter': 'pre1', 'transducer': 'trans1'}
@@ -161,11 +161,11 @@ class TestEdfWriter(unittest.TestCase):
         np.testing.assert_equal(ann_text[3][0:12], "annotation4_")
 
     def test_EdfWriter_BDFplus(self):
-        channel_info1 = {'label': 'test_label', 'dimension': 'mV', 'sample_rate': 100,
+        channel_info1 = {'label': 'test_label', 'dimension': 'mV', 'sample_frequency': 100,
                         'physical_max': 1.0, 'physical_min': -1.0,
                         'digital_max': 8388607, 'digital_min': -8388608,
                         'prefilter': 'pre1', 'transducer': 'trans1'}
-        channel_info2 = {'label': 'test_label', 'dimension': 'mV', 'sample_rate': 100,
+        channel_info2 = {'label': 'test_label', 'dimension': 'mV', 'sample_frequency': 100,
                               'physical_max': 1.0, 'physical_min': -1.0,
                             'digital_max': 8388607, 'digital_min': -8388608,
                             'prefilter': 'pre1', 'transducer': 'trans1'}
@@ -230,11 +230,11 @@ class TestEdfWriter(unittest.TestCase):
         del f
 
     def test_EdfWriter_BDFplus2(self):
-        channel_info1 = {'label': 'test_label', 'dimension': 'mV', 'sample_rate': 100,
+        channel_info1 = {'label': 'test_label', 'dimension': 'mV', 'sample_frequency': 100,
                         'physical_max': 1.0, 'physical_min': -1.0,
                         'digital_max': 8388607, 'digital_min': -8388608,
                         'prefilter': 'pre1', 'transducer': 'trans1'}
-        channel_info2 = {'label': 'test_label', 'dimension': 'mV', 'sample_rate': 100,
+        channel_info2 = {'label': 'test_label', 'dimension': 'mV', 'sample_frequency': 100,
                               'physical_max': 1.0, 'physical_min': -1.0,
                             'digital_max': 8388607, 'digital_min': -8388608,
                             'prefilter': 'pre1', 'transducer': 'trans1'}
@@ -290,11 +290,11 @@ class TestEdfWriter(unittest.TestCase):
         del f
 
     def test_EdfWriter_BDF(self):
-        channel_info1 = {'label': 'test_label', 'dimension': 'mV', 'sample_rate': 100,
+        channel_info1 = {'label': 'test_label', 'dimension': 'mV', 'sample_frequency': 100,
                         'physical_max': 1.0, 'physical_min': -1.0,
                         'digital_max': 8388607, 'digital_min': -8388608,
                         'prefilter': 'pre1', 'transducer': 'trans1'}
-        channel_info2 = {'label': 'test_label', 'dimension': 'mV', 'sample_rate': 100,
+        channel_info2 = {'label': 'test_label', 'dimension': 'mV', 'sample_frequency': 100,
                             'physical_max': 1.0, 'physical_min': -1.0,
                             'digital_max': 8388607, 'digital_min': -8388608,
                             'prefilter': 'pre1', 'transducer': 'trans1'}
@@ -321,7 +321,7 @@ class TestEdfWriter(unittest.TestCase):
         del f
 
     def test_EdfWriter_EDFplus(self):
-        channel_info = {'label': 'test_label', 'dimension': 'mV', 'sample_rate': 100,
+        channel_info = {'label': 'test_label', 'dimension': 'mV', 'sample_frequency': 100,
                         'physical_max': 1.0, 'physical_min': -1.0,
                         'digital_max': 32767, 'digital_min': -32768,
                         'prefilter': 'pre1', 'transducer': 'trans1'}
@@ -360,11 +360,11 @@ class TestEdfWriter(unittest.TestCase):
 
 
     def test_EdfWriter_EDF(self):
-        channel_info1 = {'label': 'test_label', 'dimension': 'mV', 'sample_rate': 100,
+        channel_info1 = {'label': 'test_label', 'dimension': 'mV', 'sample_frequency': 100,
                         'physical_max': 1.0, 'physical_min': -1.0,
                         'digital_max': 32767, 'digital_min': -32768,
                         'prefilter': 'pre1', 'transducer': 'trans1'}
-        channel_info2 = {'label': 'test_label', 'dimension': 'mV', 'sample_rate': 100,
+        channel_info2 = {'label': 'test_label', 'dimension': 'mV', 'sample_frequency': 100,
                               'physical_max': 1.0, 'physical_min': -1.0,
                             'digital_max': 32767, 'digital_min': -32768,
                             'prefilter': 'pre1', 'transducer': 'trans1'}
@@ -391,11 +391,11 @@ class TestEdfWriter(unittest.TestCase):
 
 
     def test_SampleWriting(self):
-        channel_info1 = {'label':'test_label1', 'dimension':'mV', 'sample_rate':100,
+        channel_info1 = {'label':'test_label1', 'dimension':'mV', 'sample_frequency':100,
                           'physical_max':1.0,'physical_min':-1.0,
                           'digital_max':8388607,'digital_min':-8388608,
                           'prefilter':'pre1','transducer':'trans1'}
-        channel_info2 = {'label':'test_label2', 'dimension':'mV', 'sample_rate':100,
+        channel_info2 = {'label':'test_label2', 'dimension':'mV', 'sample_frequency':100,
                           'physical_max':1.0,'physical_min':-1.0,
                           'digital_max':8388607,'digital_min':-8388608,
                           'prefilter':'pre2','transducer':'trans2'}
@@ -423,11 +423,11 @@ class TestEdfWriter(unittest.TestCase):
         self.assertEqual(f.filetype, pyedflib.FILETYPE_BDFPLUS)
 
     def test_EdfWriter_EDF_contextmanager(self):
-        channel_info1 = {'label': 'test_label', 'dimension': 'mV', 'sample_rate': 100,
+        channel_info1 = {'label': 'test_label', 'dimension': 'mV', 'sample_frequency': 100,
                         'physical_max': 1.0, 'physical_min': -1.0,
                         'digital_max': 32767, 'digital_min': -32768,
                         'prefilter': 'pre1', 'transducer': 'trans1'}
-        channel_info2 = {'label': 'test_label', 'dimension': 'mV', 'sample_rate': 100,
+        channel_info2 = {'label': 'test_label', 'dimension': 'mV', 'sample_frequency': 100,
                               'physical_max': 1.0, 'physical_min': -1.0,
                             'digital_max': 32767, 'digital_min': -32768,
                             'prefilter': 'pre1', 'transducer': 'trans1'}
@@ -447,11 +447,11 @@ class TestEdfWriter(unittest.TestCase):
             self.assertEqual(f.filetype, pyedflib.FILETYPE_EDF)
 
     def test_SampleWritingContextManager(self):
-        channel_info1 = {'label':'test_label1', 'dimension':'mV', 'sample_rate':100,
+        channel_info1 = {'label':'test_label1', 'dimension':'mV', 'sample_frequency':100,
                           'physical_max':1.0,'physical_min':-1.0,
                           'digital_max':8388607,'digital_min':-8388608,
                           'prefilter':'pre1','transducer':'trans1'}
-        channel_info2 = {'label':'test_label2', 'dimension':'mV', 'sample_rate':100,
+        channel_info2 = {'label':'test_label2', 'dimension':'mV', 'sample_frequency':100,
                           'physical_max':1.0,'physical_min':-1.0,
                           'digital_max':8388607,'digital_min':-8388608,
                           'prefilter':'pre2','transducer':'trans2'}
@@ -483,11 +483,11 @@ class TestEdfWriter(unittest.TestCase):
         np.testing.assert_almost_equal(data2, data2_read)
 
     def test_SampleWriting2(self):
-        channel_info1 = {'label':'test_label1', 'dimension':'mV', 'sample_rate':100,
+        channel_info1 = {'label':'test_label1', 'dimension':'mV', 'sample_frequency':100,
                           'physical_max':1.0,'physical_min':-1.0,
                           'digital_max':8388607,'digital_min':-8388608,
                           'prefilter':'pre1','transducer':'trans1'}
-        channel_info2 = {'label':'test_label2', 'dimension':'mV', 'sample_rate':100,
+        channel_info2 = {'label':'test_label2', 'dimension':'mV', 'sample_frequency':100,
                           'physical_max':1.0,'physical_min':-1.0,
                           'digital_max':8388607,'digital_min':-8388608,
                           'prefilter':'pre2','transducer':'trans2'}
@@ -514,16 +514,16 @@ class TestEdfWriter(unittest.TestCase):
         np.testing.assert_equal(len(data2), len(data2_read))
         np.testing.assert_almost_equal(data1, data1_read)
         np.testing.assert_almost_equal(data2, data2_read)
-        
+
     def test_SampleWriting_digital(self):
 
         dmin, dmax = [0, 1024]
         pmin, pmax = [0, 1.0]
-        channel_info1 = {'label':'test_label1', 'dimension':'mV', 'sample_rate':100,
+        channel_info1 = {'label':'test_label1', 'dimension':'mV', 'sample_frequency':100,
                           'physical_max':pmax,'physical_min':pmin,
                           'digital_max':dmax,'digital_min':dmin,
                           'prefilter':'pre1','transducer':'trans1'}
-        channel_info2 = {'label':'test_label2', 'dimension':'mV', 'sample_rate':100,
+        channel_info2 = {'label':'test_label2', 'dimension':'mV', 'sample_frequency':100,
                           'physical_max':pmax,'physical_min':pmin,
                           'digital_max':dmax,'digital_min':dmin,
                           'prefilter':'pre2','transducer':'trans2'}
@@ -562,14 +562,14 @@ class TestEdfWriter(unittest.TestCase):
         data2_read = (f.readSignal(1) - pmin)/((pmax-pmin)/(dmax-dmin)) # converting back to digital
         self.assertEqual(f.filetype, pyedflib.FILETYPE_EDFPLUS)
         del f
-    
+
         np.testing.assert_equal(len(data1), len(data1_read))
         np.testing.assert_equal(len(data2), len(data2_read))
         np.testing.assert_almost_equal(data1, data1_read)
         np.testing.assert_almost_equal(data2, data2_read)
 
     def test_TestRoundingEDF(self):
-        channel_info1 = {'label':'test_label1', 'dimension':'mV', 'sample_rate':100,
+        channel_info1 = {'label':'test_label1', 'dimension':'mV', 'sample_frequency':100,
                           'physical_max':1.0,'physical_min':-1.0,
                           'digital_max':32767,'digital_min':-32768,
                           'prefilter':'pre1','transducer':'trans1'}
@@ -609,7 +609,7 @@ class TestEdfWriter(unittest.TestCase):
         np.testing.assert_almost_equal(data1_read, data2_read, decimal=4)
 
     def test_AnnotationWriting(self):
-        channel_info = {'label': 'test_label', 'dimension': 'mV', 'sample_rate': 100,
+        channel_info = {'label': 'test_label', 'dimension': 'mV', 'sample_frequency': 100,
                         'physical_max': 1.0, 'physical_min': -1.0,
                         'digital_max': 8388607, 'digital_min': -8388608,
                         'prefilter': 'pre1', 'transducer': 'trans1'}
@@ -645,7 +645,7 @@ class TestEdfWriter(unittest.TestCase):
         np.testing.assert_equal(ann_text[3][0:12], "annotation4_")
 
     def test_AnnotationWritingUTF8(self):
-        channel_info = {'label': 'test_label', 'dimension': 'mV', 'sample_rate': 100,
+        channel_info = {'label': 'test_label', 'dimension': 'mV', 'sample_frequency': 100,
                         'physical_max': 1.0, 'physical_min': -1.0,
                         'digital_max': 8388607, 'digital_min': -8388608,
                         'prefilter': u'test', 'transducer': 'trans1'}
@@ -679,7 +679,7 @@ class TestEdfWriter(unittest.TestCase):
         np.testing.assert_equal(ann_text[2], "abc")
 
     def test_BytesChars(self):
-        channel_info = {'label': b'test_label', 'dimension': b'mV', 'sample_rate': 100,
+        channel_info = {'label': b'test_label', 'dimension': b'mV', 'sample_frequency': 100,
                         'physical_max': 1.0, 'physical_min': -1.0,
                         'digital_max': 8388607, 'digital_min': -8388608,
                         'prefilter': b'      ', 'transducer': b'trans1'}
@@ -716,13 +716,13 @@ class TestEdfWriter(unittest.TestCase):
     def test_physical_range_inequality(self):
         # Prepare data
         channel_data1 = np.sin(np.arange(1,1001))
-        channel_info1 = {'label': 'test_label_sin', 'dimension': 'mV', 'sample_rate': 100,
+        channel_info1 = {'label': 'test_label_sin', 'dimension': 'mV', 'sample_frequency': 100,
                         'physical_max': max(channel_data1), 'physical_min': min(channel_data1),
                         'digital_max': 8388607, 'digital_min': -8388608,
                         'prefilter': 'pre1', 'transducer': 'trans1'}
 
         channel_data2 = np.zeros((1000,))
-        channel_info2 = {'label': 'test_label_zero', 'dimension': 'mV', 'sample_rate': 100,
+        channel_info2 = {'label': 'test_label_zero', 'dimension': 'mV', 'sample_frequency': 100,
                             'physical_max': max(channel_data2), 'physical_min': min(channel_data2),
                             'digital_max': 8388607, 'digital_min': -8388608,
                             'prefilter': 'pre1', 'transducer': 'trans1'}
@@ -730,17 +730,17 @@ class TestEdfWriter(unittest.TestCase):
                                 file_type=pyedflib.FILETYPE_BDF)
         f.setSignalHeader(0,channel_info1)
         f.setSignalHeader(1,channel_info2)
-        
+
         # Test that assertion fails
         self.assertRaises(AssertionError, f.writeSamples, [channel_data1, channel_data2])
 
 
     def test_gender_setting_correctly(self):
-        channel_info1 = {'label': 'test_label1', 'dimension': 'mV', 'sample_rate': 100,
+        channel_info1 = {'label': 'test_label1', 'dimension': 'mV', 'sample_frequency': 100,
                          'physical_max': 3.0, 'physical_min': -3.0,
                          'digital_max': 32767, 'digital_min': -32768,
                          'prefilter': 'pre1', 'transducer': 'trans1'}
-        channel_info2 = {'label': 'test_label2', 'dimension': 'mV', 'sample_rate': 100,
+        channel_info2 = {'label': 'test_label2', 'dimension': 'mV', 'sample_frequency': 100,
                          'physical_max': 3.0, 'physical_min': -3.0,
                          'digital_max': 32767, 'digital_min': -32768,
                          'prefilter': 'pre1', 'transducer': 'trans1'}

--- a/pyedflib/tests/test_highlevel.py
+++ b/pyedflib/tests/test_highlevel.py
@@ -78,13 +78,17 @@ class TestHighLevel(unittest.TestCase):
             self.assertTrue(os.path.isfile(file))
             self.assertGreater(os.path.getsize(file), 0)
             self.assertTrue(success)
-            
+
             signals2, signal_headers2, header2 = highlevel.read_edf(file)
-    
+
             self.assertEqual(len(signals2), 5)
             self.assertEqual(len(signals2), len(signal_headers2))
             for shead1, shead2 in zip(signal_headers1, signal_headers2):
-                self.assertDictEqual(shead1, shead2)
+                # When only 'sample_rate' is present, we use its value to write
+                # the file, ignoring 'sample_frequency', which means that when
+                # we read it back only the 'sample_rate' value is present.
+                self.assertDictEqual({**shead1, 'sample_frequency': shead1['sample_rate']},
+                                     shead2)
             np.testing.assert_allclose(signals, signals2, atol=0.01)
             if file_type in [-1, 1, 3]:
                 self.assertDictEqual(header, header2)
@@ -102,7 +106,11 @@ class TestHighLevel(unittest.TestCase):
             self.assertEqual(len(signals2), len(signal_headers2))
             np.testing.assert_array_equal(signals, signals2)
             for shead1, shead2 in zip(signal_headers1, signal_headers2):
-                self.assertDictEqual(shead1, shead2)
+                # When only 'sample_rate' is present, we use its value to write
+                # the file, ignoring 'sample_frequency', which means that when
+                # we read it back only the 'sample_rate' value is present.
+                self.assertDictEqual({**shead1, 'sample_frequency': shead1['sample_rate']},
+                                     shead2)
             # EDF/BDF header writing does not correctly work yet
             if file_type in [-1, 1, 3]:
                 self.assertDictEqual(header, header2)

--- a/pyedflib/tests/test_highlevel.py
+++ b/pyedflib/tests/test_highlevel.py
@@ -138,13 +138,6 @@ class TestHighLevel(unittest.TestCase):
         signals2, _, _ = highlevel.read_edf(self.edfplus_data_file, digital=False, verbose=True)
         np.testing.assert_allclose(signals, signals2, atol=0.0001)
 
-    # def test_read_write_decimal_sample_rates_smaller_one(self):
-    #     signals = np.random.randint(-2048, 2048, [3, 256*60])
-    #     highlevel.write_edf_quick(self.edfplus_data_file, signals.astype(np.int32), sfreq=1/3, digital=True)
-    #     signals2, _, _ = highlevel.read_edf(self.edfplus_data_file, digital=True, verbose=True)
-    #     np.testing.assert_allclose(signals, signals2)
-
-
 
     def test_read_write_diff_sfreq(self):
         

--- a/pyedflib/tests/test_highlevel.py
+++ b/pyedflib/tests/test_highlevel.py
@@ -128,7 +128,7 @@ class TestHighLevel(unittest.TestCase):
         np.testing.assert_allclose(signals, signals2, atol=0.00002)
 
 
-    def test_read_write_decimal_sample_rates(self):
+    def test_read_write_decimal_sample_frequencies(self):
         signals = np.random.randint(-2048, 2048, [3, 256*60])
         highlevel.write_edf_quick(self.edfplus_data_file, signals.astype(np.int32), sfreq=8.5, digital=True)
         signals2, _, _ = highlevel.read_edf(self.edfplus_data_file, digital=True, verbose=True)
@@ -153,7 +153,7 @@ class TestHighLevel(unittest.TestCase):
         sheaders = []
         for sfreq in sfreqs:
             signals.append(np.random.randint(-2048, 2048, sfreq*60).astype(np.int32))
-            shead = highlevel.make_signal_header('ch{}'.format(sfreq), sample_rate=sfreq)
+            shead = highlevel.make_signal_header('ch{}'.format(sfreq), sample_frequency=sfreq)
             sheaders.append(shead)
         highlevel.write_edf(self.edfplus_data_file, signals, sheaders, digital=True)
         signals2, sheaders2, _ = highlevel.read_edf(self.edfplus_data_file, digital=True)
@@ -164,7 +164,7 @@ class TestHighLevel(unittest.TestCase):
         
         # test digital and dmin wrong
         signals =[np.random.randint(-2048, 2048, 256*60).astype(np.int32)]
-        sheaders = [highlevel.make_signal_header('ch1', sample_rate=256)]
+        sheaders = [highlevel.make_signal_header('ch1', sample_frequency=256)]
         sheaders[0]['digital_min'] = -128
         sheaders[0]['digital_max'] = 128
         with self.assertRaises(AssertionError):
@@ -172,7 +172,7 @@ class TestHighLevel(unittest.TestCase):
         
         # test pmin wrong
         signals = [np.random.randint(-2048, 2048, 256*60)]
-        sheaders = [highlevel.make_signal_header('ch1', sample_rate=256)]
+        sheaders = [highlevel.make_signal_header('ch1', sample_frequency=256)]
         sheaders[0]['physical_min'] = -200
         sheaders[0]['physical_max'] = 200
         with self.assertRaises(AssertionError):
@@ -290,7 +290,7 @@ class TestHighLevel(unittest.TestCase):
         siglen = 256* 155
         signals = np.random.rand(10, siglen)
         sheads = highlevel.make_signal_headers([str(x) for x in range(10)],
-                                              sample_rate=256, physical_max=1,
+                                              sample_frequency=256, physical_max=1,
                                               physical_min=-1)
 
         valid_block_sizes = [-1, 1, 5, 31]


### PR DESCRIPTION
Resolves #117 

The terms 'sample_rate' and 'sample_frequency' were used
interchangeably in the codebase, which is valid as long as the
record duration is 1 second, but they stop being the same when
the record duration is any other value. I followed the meaning
established in the documentation, where 'sample_frequency' is
taken to represent the number of samples per signal per record,
and 'sample_rate' is the number samples per signal per second.

This represents a breaking change to pyedflib's API, as it changes
the name of various EdfWriter method parameters and keys
in the signal dictionaries returned by EdfReader methods.
However, it conforms to the terminology used in the EDF spec
(that the header displays the number of samples in each data
record) as well as edflib function names.