### PR TITLE
non-empty data check in edfwriter to prevent unknown OS error

### DIFF
--- a/pyedflib/edfwriter.py
+++ b/pyedflib/edfwriter.py
@@ -690,8 +690,11 @@ class EdfWriter(object):
         """
 
 
-        if (len(data_list) != len(self.channels)) or (len(data_list) == 0):
-            raise WrongInputSize(len(data_list))
+        if (len(data_list) == 0:
+            raise WrongInputSize('Data list is empty') 
+        if (len(data_list) != len(self.channels)):
+            raise WrongInputSize('Number of channels ({}) \
+             unequal to length of data ({})'.format(len(self.channels), len(data_list)))
 
         if any([np.isfortran(s) for s in data_list if isinstance(s, np.ndarray)]) or \
                 (isinstance(data_list, np.ndarray) and np.isfortran(data_list)):

--- a/pyedflib/edfwriter.py
+++ b/pyedflib/edfwriter.py
@@ -690,7 +690,7 @@ class EdfWriter(object):
         """
 
 
-        if (len(data_list) != len(self.channels)):
+        if (len(data_list) != len(self.channels)) or (len(data_list) == 0):
             raise WrongInputSize(len(data_list))
 
         if any([np.isfortran(s) for s in data_list if isinstance(s, np.ndarray)]) or \

--- a/pyedflib/edfwriter.py
+++ b/pyedflib/edfwriter.py
@@ -690,7 +690,7 @@ class EdfWriter(object):
         """
 
 
-        if (len(data_list) == 0:
+        if (len(data_list)) == 0:
             raise WrongInputSize('Data list is empty') 
         if (len(data_list) != len(self.channels)):
             raise WrongInputSize('Number of channels ({}) \


### PR DESCRIPTION
Ran into an issue on Ubuntu and Windows that would cause edfWriter to wither hang or crash and return `IOError('Unknown error while calling blockWriteSamples')` (edfWriter.py:741). Investigated and found this occurs if `len(data_list) == 0` in `edfWriter.writeSamples()`.

Added another conditional for this on line 693 to save future users effort in debugging.