### PR TITLE
Fix annotation bytestring

### DIFF
--- a/pyedflib/edfwriter.py
+++ b/pyedflib/edfwriter.py
@@ -769,6 +769,10 @@ class EdfWriter(object):
         """
         if self.file_type in [FILETYPE_EDF, FILETYPE_BDF]:
             raise TypeError('Trying to write annotation to EDF/BDF, must use EDF+/BDF+')
+
+        if isinstance(duration_in_seconds, bytes):
+            duration_in_seconds = float(duration_in_seconds)
+            
         if str_format == 'utf-8':
             if duration_in_seconds >= 0:
                 return write_annotation_utf8(self.handle, np.round(onset_in_seconds*10000).astype(int), np.round(duration_in_seconds*10000).astype(int), du(description))

--- a/pyedflib/highlevel.py
+++ b/pyedflib/highlevel.py
@@ -354,9 +354,11 @@ def read_edf(edf_file, ch_nrs=None, ch_names=None, digital=False, verbose=False)
         signal_headers = [f.getSignalHeaders()[c] for c in ch_nrs]
 
         # add annotations to header
-        annotations = f.read_annotation()
-        annotations = [[float(t)/10000000, d if d else -1, x.decode()] for t,d,x in annotations]
+        annotations = f.readAnnotations()
+        annotations = [[s, d, a] for s,d,a in zip(*annotations)]
         header['annotations'] = annotations
+
+
         signals = []
         for i,c in enumerate(tqdm(ch_nrs, desc='Reading Channels',
                                   disable=not verbose)):

--- a/pyedflib/tests/test_highlevel.py
+++ b/pyedflib/tests/test_highlevel.py
@@ -315,8 +315,20 @@ class TestHighLevel(unittest.TestCase):
                                    atol=0.0001)
 
 
-    # def test_rename_channels(self):
-        # raise NotImplementedError
+    def test_annotation_bytestring(self):
+        header = highlevel.make_header(technician='tech', recording_additional='radd',
+                                                patientname='name', patient_additional='padd',
+                                                patientcode='42', equipment='eeg', admincode='420',
+                                                gender='Male', birthdate='05.09.1980')
+        annotations = [[0.01, b'-1', 'begin'],[0.5, b'-1', 'middle'],[10, -1, 'end']]
+        header['annotations'] = annotations
+        signal_headers = highlevel.make_signal_headers(['ch'+str(i) for i in range(3)])
+        signals = np.random.rand(3, 256*300)*200 #5 minutes of eeg
+        highlevel.write_edf(self.edfplus_data_file, signals, signal_headers, header)
+        _,_,header2 = highlevel.read_edf(self.edfplus_data_file)
+        highlevel.write_edf(self.edfplus_data_file, signals, signal_headers, header)
+        _,_,header3 = highlevel.read_edf(self.edfplus_data_file)
+        self.assertEqual(header2['annotations'], header3['annotations'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
fixes #119 

I changed the way annotations are loaded slightly, and there is an explicit type conversion happening now

I also use the internal function `readAnnotations` instead of the Cython `read_annotations`, which already has all the type conversions that are needed. This should have been the way anyway.