### PR TITLE
Cleanup travis buildscript

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,6 @@ matrix:
       python: 3.6
       env:
         - NUMPYSPEC=numpy
-        - MATPLOTLIBSPEC=matplotlib
         - CYTHONSPEC=cython
         - USE_WHEEL=1
         - LINUX_WHEEL=1
@@ -53,7 +52,6 @@ matrix:
       sudo: true
       env:
         - NUMPYSPEC=numpy
-        - MATPLOTLIBSPEC=matplotlib
         - CYTHONSPEC=cython
         - USE_SDIST=1
         - USE_SCIPY=1
@@ -65,7 +63,6 @@ matrix:
       sudo: true
       env:
         - NUMPYSPEC=numpy
-        - MATPLOTLIBSPEC=matplotlib
         - CYTHONSPEC=cython
         - MANYLINUX=0
     - os: linux
@@ -74,7 +71,6 @@ matrix:
       sudo: true
       env:
         - NUMPYSPEC=numpy
-        - MATPLOTLIBSPEC=matplotlib
         - CYTHONSPEC=cython
         - MANYLINUX=0
     - os: osx
@@ -127,7 +123,6 @@ before_install:
         pip install --upgrade pip
         pip install --upgrade wheel
         pip install $NUMPYSPEC
-        pip install $MATPLOTLIBSPEC
         pip install $CYTHONSPEC
         pip install pytest pytest-cov coverage codecov futures
         mkdir ${TRAVIS_BUILD_DIR}/wheelhouse

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,20 +15,20 @@ matrix:
         - docker
       env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64
            PLAT=manylinux1_x86_64
-           MANYLINUX=1
+           MANYLINUX=0
     - sudo: required
       services:
         - docker
       env: DOCKER_IMAGE=quay.io/pypa/manylinux2010_i686
            PRE_CMD=linux32
            PLAT=manylinux1_i686
-           MANYLINUX=1
+           MANYLINUX=0
     - sudo: required
       services:
         - docker
       env: DOCKER_IMAGE=quay.io/pypa/manylinux2010_x86_64
            PLAT=manylinux2010_x86_64
-           MANYLINUX=1
+           MANYLINUX=0
     - sudo: required
       arch: arm64-graviton2
       group: edge
@@ -37,7 +37,7 @@ matrix:
         - docker
       env: DOCKER_IMAGE=quay.io/pypa/manylinux2014_aarch64
            PLAT=manylinux2014_aarch64
-           MANYLINUX=1
+           MANYLINUX=0
     - os: linux
       python: 3.6
       env:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ install:
   - "util\\appveyor\\build.cmd %PYTHON%\\python.exe -m pip install --upgrade pip"
   - "util\\appveyor\\build.cmd %PYTHON%\\python.exe -m pip install --upgrade wheel"
   - "util\\appveyor\\build.cmd %PYTHON%\\python.exe -m pip install
-     Cython nose coverage dateparser tqdm --cache-dir c:\\tmp\\pip-cache"
+     Cython nose coverage numpy dateparser tqdm --cache-dir c:\\tmp\\pip-cache"
 
 test_script:
   - "util\\appveyor\\build.cmd %PYTHON%\\python.exe setup.py build --build-lib build\\lib\\"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ install:
   - "util\\appveyor\\build.cmd %PYTHON%\\python.exe -m pip install --upgrade pip"
   - "util\\appveyor\\build.cmd %PYTHON%\\python.exe -m pip install --upgrade wheel"
   - "util\\appveyor\\build.cmd %PYTHON%\\python.exe -m pip install
-     Cython nose coverage matplotlib dateparser tqdm --cache-dir c:\\tmp\\pip-cache"
+     Cython nose coverage dateparser tqdm --cache-dir c:\\tmp\\pip-cache"
 
 test_script:
   - "util\\appveyor\\build.cmd %PYTHON%\\python.exe setup.py build --build-lib build\\lib\\"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,6 @@
 nose
 cython
 numpy
-matplotlib
 pytest
 dateparser
 tqdm

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,7 +6,6 @@ nose
 coverage
 cython
 numpy
-matplotlib
 pytest
 dateparser
 tqdm

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ deps =
     coverage
     cython
     numpy
-    matplotlib
 changedir = {envdir}
 commands =
     pytest {toxinidir}/pyedflib/tests -v

--- a/travis/build-wheels.sh
+++ b/travis/build-wheels.sh
@@ -10,11 +10,6 @@ function repair_wheel {
     fi
 }
 
-# Install a system package required by our library
-yum install -y freetype-devel
-yum install -y libpng-devel
-
-
 # Compile wheels
 for PYBIN in /opt/python/*/bin; do
     "${PYBIN}/pip" install -r /io/dev-requirements.txt

--- a/util/readthedocs/requirements.txt
+++ b/util/readthedocs/requirements.txt
@@ -3,4 +3,3 @@ cython
 pytest
 wheel
 numpydoc
-matplotlib

--- a/util/travis_osx_install.sh
+++ b/util/travis_osx_install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-brew update
+#brew update
 brew install ccache
 
 # install pyenv


### PR DESCRIPTION
I did three things:

1. remove matplotlib from the dependencies. it is only used in the `demo` folders, which I actually never looked at and I don't think is really used
2. remove `MANYLINUX=1` flags, which made travis build numpy from scratch, which failed. Now the github actions and travis should work again
3. remove `brew update`, as it's probably not necessary, and takes a long time

@holgern can you double check this is all good?