### PR TITLE
suppress warnings in tests

### DIFF
--- a/pyedflib/tests/test_edfwriter.py
+++ b/pyedflib/tests/test_edfwriter.py
@@ -716,8 +716,9 @@ class TestEdfWriter(unittest.TestCase):
     def test_physical_range_inequality(self):
         # Prepare data
         channel_data1 = np.sin(np.arange(1,1001))
+
         channel_info1 = {'label': 'test_label_sin', 'dimension': 'mV', 'sample_frequency': 100,
-                        'physical_max': max(channel_data1), 'physical_min': min(channel_data1),
+                        'physical_max': 1, 'physical_min': -1,
                         'digital_max': 8388607, 'digital_min': -8388608,
                         'prefilter': 'pre1', 'transducer': 'trans1'}
 
@@ -882,11 +883,13 @@ class TestEdfWriter(unittest.TestCase):
                          'digital_min': -32768,
                          'prefilter': 'p'*100,
                          'transducer': 't'*100}
+
         # now 4 warnings should appear.
-        with pyedflib.EdfWriter(self.edf_data_file, 1, file_type=pyedflib.FILETYPE_EDF) as f:
-            f.setSignalHeader(0,channel_info1)
-            data = np.ones(100) * 0.1
-            f.writePhysicalSamples(data)
+        with self.assertWarns(UserWarning):
+            with pyedflib.EdfWriter(self.edf_data_file, 1, file_type=pyedflib.FILETYPE_EDF) as f:
+                f.setSignalHeader(0,channel_info1)
+                data = np.ones(100) * 0.1
+                f.writePhysicalSamples(data)
 
         with pyedflib.EdfReader(self.edf_data_file) as f:
             np.testing.assert_equal(f.getLabel(0), 'l'*16)
@@ -909,10 +912,11 @@ class TestEdfWriter(unittest.TestCase):
                          'transducer': 't'}
 
         # now a warning should appear.
-        with pyedflib.EdfWriter(self.edf_data_file, 1, file_type=pyedflib.FILETYPE_EDF) as f:
-            f.setSignalHeader(0,channel_info)
-            data = np.ones(100) * 0.1
-            f.writePhysicalSamples(data)
+        with self.assertWarns(UserWarning):
+            with pyedflib.EdfWriter(self.edf_data_file, 1, file_type=pyedflib.FILETYPE_EDF) as f:
+                f.setSignalHeader(0,channel_info)
+                data = np.ones(100) * 0.1
+                f.writePhysicalSamples(data)
 
         with pyedflib.EdfReader(self.edf_data_file) as f:
             self.assertEqual(f.filetype, pyedflib.FILETYPE_EDF)

--- a/pyedflib/tests/test_edfwriter.py
+++ b/pyedflib/tests/test_edfwriter.py
@@ -873,6 +873,61 @@ class TestEdfWriter(unittest.TestCase):
             del f
 
 
+    def test_EdfWriter_more_than_80_chars(self):
+
+        channel_info1 = {'label': 'label',
+                         'dimension': 'dim',
+                         'sample_frequency': 100,
+                         'physical_max': 1,
+                         'physical_min': -1.0,
+                         'digital_max': 32767,
+                         'digital_min': -32768,
+                         'prefilter': 'pre',
+                         'transducer': 'trans'}
+
+        header = {'birthdate': '',
+                  'startdate': datetime(2021, 6, 26, 13, 16, 1),
+                  'gender': '',
+                  'admincode': '',
+                  'equipment': '',
+                  'patientcode': 'x'*40,
+                  'patient_additional': 'x'*30,
+                  'patientname': '',
+                  'recording_additional': '',
+                  'technician': ''}
+
+        # now 4 warnings should appear.
+        with self.assertWarns(UserWarning):
+            with pyedflib.EdfWriter(self.edf_data_file, 1, file_type=pyedflib.FILETYPE_EDFPLUS) as f:
+                f.setHeader(header)
+                f.setSignalHeader(0, channel_info1)
+                data = np.ones(100) * 0.1
+                f.writePhysicalSamples(data)
+
+        header = {'birthdate': '',
+                  'startdate': datetime(2021, 6, 26, 13, 16, 1),
+                  'gender': '',
+                  'admincode': '',
+                  'equipment': 'e'*20,
+                  'patientcode': 'x',
+                  'patient_additional': 'x',
+                  'patientname': '',
+                  'recording_additional': 'r'*20,
+                  'technician': 't'*20}
+
+        # now 4 warnings should appear.
+        with self.assertWarns(UserWarning):
+            with pyedflib.EdfWriter(self.edf_data_file, 1, file_type=pyedflib.FILETYPE_EDFPLUS) as f:
+                f.setHeader(header)
+                f.setSignalHeader(0, channel_info1)
+                data = np.ones(100) * 0.1
+                f.writePhysicalSamples(data)
+
+        with pyedflib.EdfReader(self.edf_data_file) as f:
+            np.testing.assert_equal(f.getEquipment(), 'e'*20)
+            np.testing.assert_equal(f.getTechnician(), 't'*20)
+
+
     def test_EdfWriter_too_long_headers(self):
         channel_info1 = {'label': 'l'*100, # this should be too long
                          'dimension': 'd'*100,

--- a/pyedflib/tests/test_highlevel.py
+++ b/pyedflib/tests/test_highlevel.py
@@ -130,7 +130,8 @@ class TestHighLevel(unittest.TestCase):
         highlevel.write_edf_quick(self.edfplus_data_file, signals.astype(np.int32), sfreq=256, digital=True)
         signals2, _, _ = highlevel.read_edf(self.edfplus_data_file, digital=True, verbose=True)
         np.testing.assert_allclose(signals, signals2)
-        signals = np.random.rand(3, 256*60)
+        signals = np.random.rand(3, 256*60) # then rescale to 0-1
+        signals = (signals - signals.min()) / (signals.max() - signals.min())
         highlevel.write_edf_quick(self.edfplus_data_file, signals, sfreq=256)
         signals2, _, _ = highlevel.read_edf(self.edfplus_data_file)
         np.testing.assert_allclose(signals, signals2, atol=0.00002)
@@ -141,7 +142,8 @@ class TestHighLevel(unittest.TestCase):
         highlevel.write_edf_quick(self.edfplus_data_file, signals.astype(np.int32), sfreq=8.5, digital=True)
         signals2, _, _ = highlevel.read_edf(self.edfplus_data_file, digital=True, verbose=True)
         np.testing.assert_allclose(signals, signals2)
-        signals = np.random.rand(3, 256*60)
+        signals = np.random.rand(3, 256*60) # then rescale to 0-1
+        signals = (signals - signals.min()) / (signals.max() - signals.min())
         highlevel.write_edf_quick(self.edfplus_data_file, signals, sfreq=8.5, digital=False)
         signals2, _, _ = highlevel.read_edf(self.edfplus_data_file, digital=False, verbose=True)
         np.testing.assert_allclose(signals, signals2, atol=0.0001)
@@ -181,7 +183,8 @@ class TestHighLevel(unittest.TestCase):
             
 
     def test_read_write_accented(self):
-        signals = np.random.rand(3, 256*60)
+        signals = np.random.rand(3, 256*60) # then rescale to 0-1
+        signals = (signals - signals.min()) / (signals.max() - signals.min())
         highlevel.write_edf_quick(self.test_accented, signals, sfreq=256)
         signals2, _, _ = highlevel.read_edf(self.test_accented)
         
@@ -190,7 +193,8 @@ class TestHighLevel(unittest.TestCase):
         self.assertTrue(os.path.isfile(self.test_accented), 'File does not exist')
 
     def test_read_unicode(self):
-        signals = np.random.rand(3, 256*60)
+        signals = np.random.rand(3, 256*60) # then rescale to 0-1
+        signals = (signals - signals.min()) / (signals.max() - signals.min())
         success = highlevel.write_edf_quick(self.edfplus_data_file, signals, sfreq=256)
         self.assertTrue(success)
         shutil.copy(self.edfplus_data_file, self.test_unicode)
@@ -225,6 +229,7 @@ class TestHighLevel(unittest.TestCase):
         header['annotations'] = annotations
         signal_headers = highlevel.make_signal_headers(['ch'+str(i) for i in range(3)])
         signals = np.random.rand(3, 256*300)*200 #5 minutes of eeg
+        signals = (signals - signals.min()) / (signals.max() - signals.min())
         highlevel.write_edf(self.personalized, signals, signal_headers, header)
     
         
@@ -267,6 +272,7 @@ class TestHighLevel(unittest.TestCase):
     def test_drop_channel(self):
         signal_headers = highlevel.make_signal_headers(['ch'+str(i) for i in range(5)])
         signals = np.random.rand(5, 256*300)*200 #5 minutes of eeg
+        signals = (signals - signals.min()) / (signals.max() - signals.min())
         highlevel.write_edf(self.drop_from, signals, signal_headers)
         
         dropped = highlevel.drop_channels(self.drop_from, to_keep=['ch1', 'ch2'], verbose=True)


### PR DESCRIPTION
just remove the warnings that the tests give.

add a catch to the warnings, so that we can make sure that they are displayed