### PR TITLE
improved speedup write with F-contiguous arrays

### DIFF
--- a/pyedflib/edfwriter.py
+++ b/pyedflib/edfwriter.py
@@ -817,14 +817,14 @@ class EdfWriter(object):
             del dataRecord
             dataRecord = np.array([], dtype=np.int32 if digital else None)
             for i in np.arange(len(data_list)):
-                dataRecord = np.append(dataRecord,data_list[i].ravel()[int(ind[i]):int(ind[i]+sampleFrequencies[i])])
+                dataRecord = np.append(dataRecord, data_list[i][int(ind[i]):int(ind[i]+sampleFrequencies[i])])
                 ind[i] += sampleFrequencies[i]
             if digital:
                 success = self.blockWriteDigitalSamples(dataRecord)
             else:
                 success = self.blockWritePhysicalSamples(dataRecord)
 
-            if success<0:
+            if success < 0:
                 raise IOError('Unknown error while calling blockWriteSamples')
 
             for i in np.arange(len(data_list)):
@@ -837,7 +837,7 @@ class EdfWriter(object):
             lastSampleInd = int(np.max(data_list[i].shape) - ind[i])
             lastSampleInd = int(np.min((lastSampleInd,sampleFrequencies[i])))
             if lastSampleInd > 0:
-                lastSamples[:lastSampleInd] = data_list[i].ravel()[-lastSampleInd:]
+                lastSamples[:lastSampleInd] = data_list[i][-lastSampleInd:]
                 if digital:
                     success = self.writeDigitalSamples(lastSamples)
                 else:

--- a/pyedflib/edfwriter.py
+++ b/pyedflib/edfwriter.py
@@ -784,10 +784,16 @@ class EdfWriter(object):
             raise WrongInputSize('Number of channels ({}) \
              unequal to length of data ({})'.format(len(self.channels), len(data_list)))
 
-        if any([np.isfortran(s) for s in data_list if isinstance(s, np.ndarray)]) or \
-                (isinstance(data_list, np.ndarray) and np.isfortran(data_list)):
+        # Check for F-contiguous arrays
+        if any([s.flags.f_contiguous for s in data_list if isinstance(s, np.ndarray)]) or \
+                (isinstance(data_list, np.ndarray) and data_list.flags.f_contiguous):
            warnings.warn('signals are in Fortran order. Will automatically ' \
                          'transfer to C order for compatibility with edflib.')
+        if isinstance(data_list, list):
+            data_list = [s.copy(order='C') for s in data_list]
+        elif isinstance(data_list, np.ndarray) and data_list.flags.f_contiguous:
+            data_list = data_list.copy(order='C')
+        
         if digital:
             if any([not np.issubdtype(a.dtype, np.integer) for a in data_list]):
                 raise TypeError('Digital = True requires all signals in int')

--- a/pyedflib/highlevel.py
+++ b/pyedflib/highlevel.py
@@ -503,15 +503,6 @@ def write_edf(edf_file, signals, signal_headers, header=None, digital=False,
     # get annotations, in format [[timepoint, duration, description], [...]]
     annotations = header.get('annotations', [])
 
-    if any([s.flags.f_contiguous for s in signals]) or \
-        (isinstance(signals, np.ndarray) and signals.flags.f_contiguous):
-           warnings.warn('signals are in Fortran order. Will automatically ' \
-                         'transfer to C order for compatibility with edflib.')
-    if isinstance(signals, list):
-        signals = [s.copy(order='C') for s in signals]
-    elif isinstance(signals, np.ndarray) and signals.flags.f_contiguous:
-        signals = signals.copy(order='C')
-
     with pyedflib.EdfWriter(edf_file, n_channels=n_channels, file_type=file_type) as f:
         f.setDatarecordDuration(int(100000 * block_size))
         f.setSignalHeaders(signal_headers)

--- a/pyedflib/highlevel.py
+++ b/pyedflib/highlevel.py
@@ -503,13 +503,13 @@ def write_edf(edf_file, signals, signal_headers, header=None, digital=False,
     # get annotations, in format [[timepoint, duration, description], [...]]
     annotations = header.get('annotations', [])
 
-    if any([np.isfortran(s) for s in signals]) or \
-        (isinstance(signals, np.ndarray) and np.isfortran(signals)):
+    if any([s.flags.f_contiguous for s in signals]) or \
+        (isinstance(signals, np.ndarray) and signals.flags.f_contiguous):
            warnings.warn('signals are in Fortran order. Will automatically ' \
                          'transfer to C order for compatibility with edflib.')
     if isinstance(signals, list):
-        signals = [s.copy(order='C') if np.isfortran(s) else s for s in signals]
-    elif isinstance(signals, np.ndarray) and np.isfortran(signals):
+        signals = [s.copy(order='C') for s in signals]
+    elif isinstance(signals, np.ndarray) and signals.flags.f_contiguous:
         signals = signals.copy(order='C')
 
     with pyedflib.EdfWriter(edf_file, n_channels=n_channels, file_type=file_type) as f:

--- a/pyedflib/tests/test_highlevel.py
+++ b/pyedflib/tests/test_highlevel.py
@@ -136,6 +136,24 @@ class TestHighLevel(unittest.TestCase):
         signals2, _, _ = highlevel.read_edf(self.edfplus_data_file)
         np.testing.assert_allclose(signals, signals2, atol=0.00002)
 
+    def test_fortran_write(self):
+        # Create Fortran contiguous array
+        signals = np.random.randint(-2048,2048,[4, 5000000])
+        signals = np.asfortranarray(signals)
+        # Write
+        highlevel.write_edf_quick(self.edfplus_data_file, signals.astype(np.int32), sfreq=250, digital=True)
+        # Read and check
+        signals2, _, _ = highlevel.read_edf(self.edfplus_data_file, digital=True, verbose=True)
+        np.testing.assert_allclose(signals, signals2)
+
+        # Create Fortran contiguous list
+        signals = [np.random.randint(-2048,2048,(5000000,))]*4
+        # Write
+        highlevel.write_edf_quick(self.edfplus_data_file, signals, sfreq=250, digital=True)
+        # Read and check
+        signals2, _, _ = highlevel.read_edf(self.edfplus_data_file, digital=True, verbose=True)
+        np.testing.assert_allclose(signals, signals2)
+
 
     def test_read_write_decimal_sample_frequencies(self):
         signals = np.random.randint(-2048, 2048, [3, 256*60])


### PR DESCRIPTION
Referencing discussion in #92 all Fortran-contiguous arrays are transformed before writing. This vastly improves write speed for this kind of arrays.