### PR TITLE
Correct “protokoll” to “protocol” in description

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ What is pyEDFlib
 pyEDFlib is a python library to read/write EDF+/BDF+ files based on EDFlib.
 
 EDF means `European Data Format`_ and was firstly published `Kemp1992`_.
-In 2003, an improved version of the file protokoll named EDF+ has been published and can be found at `Kemp2003`_.
+In 2003, an improved version of the file protocol named EDF+ has been published and can be found at `Kemp2003`_.
 
 The EDF/EDF+ format saves all data with 16 Bit. A version which saves all data with 24 Bit,
 was introduces by the compony `BioSemi`_.


### PR DESCRIPTION
Uses the English spelling “protocol” to match the surrounding English text.