### PR TITLE
np.float is deprecated

### DIFF
--- a/pyedflib/highlevel.py
+++ b/pyedflib/highlevel.py
@@ -385,7 +385,7 @@ def read_edf(edf_file, ch_nrs=None, ch_names=None, digital=False, verbose=False)
         sfreqs = [_get_sample_frequency(shead) for shead in signal_headers]
         all_sfreq_same = sfreqs[1:]==sfreqs[:-1]
         if all_sfreq_same:
-            dtype = np.int32 if digital else np.float
+            dtype = np.int32 if digital else float
             signals = np.array(signals, dtype=dtype)
 
     assert len(signals)==len(signal_headers), 'Something went wrong, lengths'\

--- a/pyedflib/tests/test_edfwriter.py
+++ b/pyedflib/tests/test_edfwriter.py
@@ -534,8 +534,8 @@ class TestEdfWriter(unittest.TestCase):
         f.setSignalHeader(0,channel_info1)
         f.setSignalHeader(1,channel_info2)
 
-        data1 = np.arange(500, dtype=np.float)
-        data2 = np.arange(500, dtype=np.float)
+        data1 = np.arange(500, dtype=float)
+        data2 = np.arange(500, dtype=float)
         data_list = []
         data_list.append(data1)
         data_list.append(data2)


### PR DESCRIPTION
`np.float` is a deprecated alias for the builtin `float`. Deprecated in NumPy 1.20; for more details: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations