### PR TITLE
Support a system-wide edflib (fix #149)

### DIFF
--- a/pyedflib/_extensions/c_edf.pxd
+++ b/pyedflib/_extensions/c_edf.pxd
@@ -6,7 +6,7 @@
 # get constants
 include "edf.pxi"
 
-cdef extern from "c/edflib.h":
+cdef extern from "edflib.h":
     int edf_set_patientcode(int, char *)
     int edfwrite_annotation_latin1(int, long long int, long long int, char *)
     int edfwrite_annotation_utf8(int, long long int, long long int, char *)


### PR DESCRIPTION
Adds an environment variable `SYSTEM_EDFLIB`. When it is set empty or to `1`, the bundled EDFlib sources are not compiled, and a system-wide `edf` library is linked instead.