### PR TITLE
Fix false positive fortran order warning

### DIFF
--- a/pyedflib/edfwriter.py
+++ b/pyedflib/edfwriter.py
@@ -785,15 +785,11 @@ class EdfWriter(object):
              unequal to length of data ({})'.format(len(self.channels), len(data_list)))
 
         # Check for F-contiguous arrays
-        if any([s.flags.f_contiguous for s in data_list if isinstance(s, np.ndarray)]) or \
-                (isinstance(data_list, np.ndarray) and data_list.flags.f_contiguous):
-           warnings.warn('signals are in Fortran order. Will automatically ' \
-                         'transfer to C order for compatibility with edflib.')
-        if isinstance(data_list, list):
-            data_list = [s.copy(order='C') for s in data_list]
-        elif isinstance(data_list, np.ndarray) and data_list.flags.f_contiguous:
-            data_list = data_list.copy(order='C')
-        
+        if not all(s.flags.c_contiguous for s in data_list):
+            warnings.warn('signals are in Fortran order. Will automatically '
+                          'transfer to C order for compatibility with edflib.')
+            data_list = np.ascontiguousarray(data_list)
+
         if digital:
             if any([not np.issubdtype(a.dtype, np.integer) for a in data_list]):
                 raise TypeError('Digital = True requires all signals in int')


### PR DESCRIPTION
Executing the example code for writing an edf file via the highlevel interface:

```python
import numpy as np
from pyedflib import highlevel

signals = np.random.rand(5, 256*300)*200
channel_names = ['ch1', 'ch2', 'ch3', 'ch4', 'ch5']
signal_headers = highlevel.make_signal_headers(channel_names, sample_frequency=256)
header = highlevel.make_header(patientname='patient_x', gender='Female')
highlevel.write_edf('edf_file.edf', signals, signal_headers, header)
```

causes the following warning to be issued, even though the array is in C-order:

`UserWarning: signals are in Fortran order. Will automatically transfer to C order for compatibility with edflib.`

This is because the [check for fortran order](https://github.com/holgern/pyedflib/blob/master/pyedflib/edfwriter.py#L788:L789) iterates over all passed arrays, which are then 1d-arrays, so they are always both c_contiguous and f_contiguous. 