### PR TITLE
Remove limit on numpy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools",
     "wheel",
-	"numpy <= 1.19.3",
+	"numpy",
     "cython"
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
There is no guarantee that a specified numpy version has a wheel package for any given python version. By relaxing the numpy version limit, pip will fetch the available numpy wheel package, instead of trying to build the specific numpy version (which may fail to complete).