### PR TITLE
use oldest-supported-numpy to build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools",
     "wheel",
-	"numpy",
+	"oldest-supported-numpy",
     "cython"
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
In the v0.1.24 release, pyedflib's cython extension was compiled against Numpy 1.22.1 for Python versions >=3.8 ([see workflow](https://github.com/holgern/pyedflib/runs/4894478892?check_suite_focus=true#step:5:2129)). Trying to import pyedflib in a local environment with a lower minor NumPy version (e.g. 1.21.5) leads to the cython error message shown in #156. 

The discussion on the introduction of an ndarray size change in NumPy 1.20.0 ([link](https://github.com/numpy/numpy/pull/16938)) contains a suggestion to use [`oldest-supported-numpy`](https://pypi.org/project/oldest-supported-numpy/) for building C/cython extensions.

I'm not sure why this error appears at the switch between 1.21 and 1.22 as the size change was introduced in 1.20 and have only tested this on Python 3.10 (Win10, 64bit), but if you and the CI workflows agree, this could be a solution :)