### PR TITLE
change win2016 to win2019 as its deprecated

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-2016, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-2019, windows-latest, macos-latest]
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     steps:
     - uses: actions/checkout@master


### PR DESCRIPTION
The Windows 2016 environment is deprecated, consider switching to windows-2019 or windows-2022 (windows-latest). For more details, see https://github.com/actions/virtual-environments/issues/4312

changed to 2019