### PR TITLE
Fix writing of annotations in very long records

### DIFF
--- a/pyedflib/edfwriter.py
+++ b/pyedflib/edfwriter.py
@@ -860,14 +860,14 @@ class EdfWriter(object):
             
         if str_format == 'utf-8':
             if duration_in_seconds >= 0:
-                return write_annotation_utf8(self.handle, np.round(onset_in_seconds*10000).astype(int), np.round(duration_in_seconds*10000).astype(int), du(description))
+                return write_annotation_utf8(self.handle, np.round(onset_in_seconds*10000).astype(np.int64), np.round(duration_in_seconds*10000).astype(int), du(description))
             else:
-                return write_annotation_utf8(self.handle, np.round(onset_in_seconds*10000).astype(int), -1, du(description))
+                return write_annotation_utf8(self.handle, np.round(onset_in_seconds*10000).astype(np.int64), -1, du(description))
         else:
             if duration_in_seconds >= 0:
-                return write_annotation_latin1(self.handle, np.round(onset_in_seconds*10000).astype(int), np.round(duration_in_seconds*10000).astype(int), u(description).encode('latin1'))
+                return write_annotation_latin1(self.handle, np.round(onset_in_seconds*10000).astype(np.int64), np.round(duration_in_seconds*10000).astype(int), u(description).encode('latin1'))
             else:
-                return write_annotation_latin1(self.handle, np.round(onset_in_seconds*10000).astype(int), -1, u(description).encode('latin1'))
+                return write_annotation_latin1(self.handle, np.round(onset_in_seconds*10000).astype(np.int64), -1, u(description).encode('latin1'))
 
     def close(self):
         """

--- a/pyedflib/tests/test_edfwriter.py
+++ b/pyedflib/tests/test_edfwriter.py
@@ -1056,6 +1056,43 @@ class TestEdfWriter(unittest.TestCase):
                 data = np.ones(100) * 0.1
                 f.writePhysicalSamples(data)
 
+    def test_write_annotations_long_long(self):
+        """check that very long recordings can store annotations"""
+        # 5 channels for one week, write annotation at 4th day
+        fs = 5
+        data = np.random.normal(size=(2,7*24*60*60*fs))
+        ch_names = ['EEG1', 'EEG2']
+        
+        with EdfWriter(self.edf_data_file, len(ch_names)) as f:
+            f.setSignalHeaders([{'label': 'EEG1',
+              'dimension': 'uV',
+              'sample_rate': 256,
+              'sample_frequency': None,
+              'physical_min': -200.0,
+              'physical_max': 200.0,
+              'digital_min': -32768,
+              'digital_max': 32767,
+              'transducer': '',
+              'prefilter': ''},
+             {'label': 'EEG2',
+              'dimension': 'uV',
+              'sample_rate': 256,
+              'sample_frequency': None,
+              'physical_min': -200.0,
+              'physical_max': 200.0,
+              'digital_min': -32768,
+              'digital_max': 32767,
+              'transducer': '',
+              'prefilter': ''}])
+
+            f.writeSamples(data)
+            for h in range(0, 4*24, 2):
+                f.writeAnnotation(h*3600, -1, f"{h} hour after start")
+                
+        with pyedflib.EdfReader(self.edf_data_file) as f:
+            annotations = f.readAnnotations()
+            self.assertEqual( len(annotations[0]), 48)
+            np.testing.assert_array_equal(annotations[0], np.arange(0, 342000, 3600*2))
 if __name__ == '__main__':
     # run_module_suite(argv=sys.argv)
     unittest.main()


### PR DESCRIPTION
Annotations starting time were indicated as Python `int`, which turned out to be interpreted by `numpy` as `int32`, limiting the annotations to a bit over 50 hours. Now it get's correctly converted to to `int64` -> `long long` which should be sufficiently long in terms of annotation seconds.