### PR TITLE
Allow file_type option in drop_channels

### DIFF
--- a/pyedflib/highlevel.py
+++ b/pyedflib/highlevel.py
@@ -644,7 +644,7 @@ def compare_edf(edf_file1, edf_file2, verbose=False):
 
 
 def drop_channels(edf_source, edf_target=None, to_keep=None, to_drop=None,
-                  verbose=False):
+                  verbose=False, file_type=-1):
     """
     Remove channels from an edf file. Save the file.
     For safety reasons, no source files can be overwritten.
@@ -666,6 +666,9 @@ def drop_channels(edf_source, edf_target=None, to_keep=None, to_drop=None,
         Strings will be interpreted as channel names. The default is None.
     verbose : bool, optional
         print progress or not. The default is False.
+    file_type: int, optional
+        choose file_type for saving.
+        EDF = 0, EDF+ = 1, BDF = 2, BDF+ = 3, automatic from extension = -1
 
     Returns
     -------
@@ -722,7 +725,7 @@ def drop_channels(edf_source, edf_target=None, to_keep=None, to_drop=None,
                                                ch_nrs=load_channels,
                                                digital=True, verbose=verbose)
 
-    write_edf(edf_target, signals, signal_headers, header, digital=True)
+    write_edf(edf_target, signals, signal_headers, header, file_type, digital=True)
     return edf_target
 
 

--- a/pyedflib/highlevel.py
+++ b/pyedflib/highlevel.py
@@ -441,6 +441,10 @@ def write_edf(edf_file, signals, signal_headers, header=None, digital=False,
         'file_type must be in range -1, 3'
     assert block_size<=60 and block_size>=-1 and block_size!=0, \
         'blocksize must be smaller or equal to 60'
+    if file_type != -1:
+        ext = os.path.splitext(edf_file)[-1]
+        assert ext == '.bdf' if file_type in [2, 3] else ext == '.edf',\
+            'file extension must match file_type (.bdf for file_type 2 or 3, otherwise .edf)'
 
     # copy objects to prevent accidential changes to mutable objects
     header = deepcopy(header)
@@ -654,7 +658,7 @@ def drop_channels(edf_source, edf_target=None, to_keep=None, to_drop=None,
     edf_source : str
         The source edf file from which to drop channels.
     edf_target : str, optional
-        Where to save the file.If None, will be edf_source+'dropped.edf'.
+        Where to save the file.If None, will be edf_source+'dropped.(edf|bdf)'.
         The default is None.
     to_keep : list, optional
          A list of channel names or indices that will be kept.
@@ -691,10 +695,11 @@ def drop_channels(edf_source, edf_target=None, to_keep=None, to_drop=None,
             'channels must be int or string'
     assert os.path.exists(edf_source), \
             'source file {} does not exist'.format(edf_source)
-    assert edf_source!=edf_target, 'For safet, target must not be source file.'
+    assert edf_source!=edf_target, 'For safety, target must not be source file.'
 
     if edf_target is None:
-        edf_target = os.path.splitext(edf_source)[0] + '_dropped.edf'
+        ext = '.bdf' if file_type in [2, 3] else '.edf'
+        edf_target = os.path.splitext(edf_source)[0] + '_dropped' + ext
     if os.path.exists(edf_target):
         warnings.warn('Target file will be overwritten')
 
@@ -725,7 +730,7 @@ def drop_channels(edf_source, edf_target=None, to_keep=None, to_drop=None,
                                                ch_nrs=load_channels,
                                                digital=True, verbose=verbose)
 
-    write_edf(edf_target, signals, signal_headers, header, file_type, digital=True)
+    write_edf(edf_target, signals, signal_headers, header, file_type=file_type, digital=True)
     return edf_target
 
 

--- a/pyedflib/tests/test_highlevel.py
+++ b/pyedflib/tests/test_highlevel.py
@@ -324,6 +324,17 @@ class TestHighLevel(unittest.TestCase):
 
         np.testing.assert_allclose(signals[3:,:], signals2, atol=0.01)
         
+        # test file_type option
+        highlevel.drop_channels(self.drop_from, self.drop_from[:-4]+'3.edf',
+                                to_keep=['ch0'], file_type=0)
+        signals2, signal_headers, header = highlevel.read_edf(self.drop_from[:-4]+'3.edf')
+        
+        self.assertEqual(header['patientname'], '') # plain EDF
+
+        with self.assertRaises(AssertionError):
+            highlevel.drop_channels(self.drop_from, self.drop_from[:-4]+'3.bdf',
+                                    to_keep=['ch0'], file_type=0)
+        
         with self.assertRaises(AssertionError):
             highlevel.drop_channels(self.drop_from, to_keep=['ch1'], to_drop=['ch3'])
 

--- a/pyedflib/tests/test_highlevel.py
+++ b/pyedflib/tests/test_highlevel.py
@@ -72,8 +72,13 @@ class TestHighLevel(unittest.TestCase):
                 header['annotations'] = []
             else:
                 header['annotations'] = annotations
-
-            file = '{}_{}_phys.edf'.format(self.tmp_testfile, file_type)
+                
+            if file_type in [-1,0,1]:
+                ext = 'edf'
+            else:
+                ext = 'bdf'
+                
+            file = '{}_{}_phys.{}'.format(self.tmp_testfile, file_type, ext)
             signals = np.random.rand(5, 256*300)*200 #5 minutes of eeg
             success = highlevel.write_edf(file, signals, signal_headers1, header, file_type=file_type)
             self.assertTrue(os.path.isfile(file))


### PR DESCRIPTION
drop_channels forces the target to EDF+ but it should allow you to choose the file type.