### PR TITLE
Fix typos found by codespell

### DIFF
--- a/README-edflib.md
+++ b/README-edflib.md
@@ -34,7 +34,7 @@ Each "generator" example creates an EDF+ or BDF+ file with sample signals.
 `test_generator` shows how to use most of the functions provided by the library and generates an
 EDF+ or BDF+ testfile with several sample signals.
 
-`sine_generator` creates a BDF+ file containing the signal "sine", a 1 Hz sinoidal waveform with a
+`sine_generator` creates a BDF+ file containing the signal "sine", a 1 Hz sinusoidal waveform with a
 sample frequency of 2048 Hz.
 
 `sweep_generator` creates a linear or logarithmic sweep through a range of frequencies in EDF+ or

--- a/doc/source/dev/how_to_release.rst
+++ b/doc/source/dev/how_to_release.rst
@@ -2,13 +2,13 @@ Guidelines for new releases for pyedflib
 ========================================
 vX.X.X refers to the release number
 
-Tag the release and trigger bulding of wheels in appvoyer
----------------------------------------------------------
+Tag the release and trigger building of wheels in appvoyer
+----------------------------------------------------------
 Change ISRELEASED in setup.py to True and commit.
 
 Appveyor will now build wheels for windows.
 
-Tag the relase with
+Tag the release with
 
 ```git tag -s vX.X.X```
 

--- a/pyedflib/_extensions/_pyedflib.pyx
+++ b/pyedflib/_extensions/_pyedflib.pyx
@@ -38,9 +38,9 @@ open_errors = {
     EDFLIB_FILE_READ_ERROR             : "a read error occurred",
     EDFLIB_FILE_ALREADY_OPENED         : "file has already been opened",
     EDFLIB_FILETYPE_ERROR              : "Wrong file type",
-    EDFLIB_FILE_WRITE_ERROR            : "a write error occured",
+    EDFLIB_FILE_WRITE_ERROR            : "a write error occurred",
     EDFLIB_NUMBER_OF_SIGNALS_INVALID   : "The number of signals is invalid",
-    EDFLIB_FILE_IS_DISCONTINUOUS       : "The file is discontinous and cannot be read",
+    EDFLIB_FILE_IS_DISCONTINUOUS       : "The file is discontinuous and cannot be read",
     EDFLIB_INVALID_READ_ANNOTS_VALUE   : "an annotation value could not be read",
     EDFLIB_FILE_ERRORS_STARTDATE      : "the file is not EDF(+) or BDF(+) compliant, the startdate is incorrect, it might contain incorrect characters, such as ':' instead of '.'",
     EDFLIB_FILE_ERRORS_STARTTIME      : "the file is not EDF(+) or BDF(+) compliant, the starttime is incorrect, it might contain incorrect characters, such as ':' instead of '.'",
@@ -70,7 +70,7 @@ write_errors = {
     EDFLIB_MAXFILES_REACHED             : "to many files opened",
     EDFLIB_FILE_ALREADY_OPENED          : "file has already been opened",
     EDFLIB_FILETYPE_ERROR               : "Wrong file type",
-    EDFLIB_FILE_WRITE_ERROR             : "a write error occured",
+    EDFLIB_FILE_WRITE_ERROR             : "a write error occurred",
     EDFLIB_NUMBER_OF_SIGNALS_INVALID    : "The number of signals is invalid",
     EDFLIB_NO_SIGNALS                   : "no signals to write",
     EDFLIB_TOO_MANY_SIGNALS             : "too many signals",
@@ -183,7 +183,7 @@ cdef class CyEdfReader:
 
     def make_buffer(self):
         """
-        utilty function to make a buffer that can hold a single datarecord. This will
+        utility function to make a buffer that can hold a single datarecord. This will
         hold the physical samples for a single data record as a numpy tensor.
 
         -  might extend to provide for N datarecord size
@@ -194,7 +194,7 @@ cdef class CyEdfReader:
         for ii in range(self.signals_in_file):
             tmp += self.samples_in_datarecord(ii)
         self.nsamples_per_record = tmp
-        dbuffer = np.zeros(tmp, dtype='float64') # will get physical samples, not the orignal digital samples
+        dbuffer = np.zeros(tmp, dtype='float64') # will get physical samples, not the original digital samples
         return dbuffer
 
     def open(self, file_name, annotations_mode=EDFLIB_READ_ALL_ANNOTATIONS, check_file_size=EDFLIB_CHECK_FILE_SIZE):

--- a/pyedflib/edfwriter.py
+++ b/pyedflib/edfwriter.py
@@ -412,7 +412,7 @@ class EdfWriter(object):
 
     def setEquipment(self, equipment):
         """
-        Sets the name of the param equipment used during the aquisition.
+        Sets the name of the param equipment used during the acquisition.
         This function is optional and can be called only after opening a file in writemode and before the first sample write action.
 
         Parameters

--- a/pyedflib/highlevel.py
+++ b/pyedflib/highlevel.py
@@ -40,9 +40,9 @@ def _get_sample_frequency(signal_header):
             else signal_header['sample_frequency'])
 
 
-def tqdm(iteratable, *args, **kwargs):
+def tqdm(iterable, *args, **kwargs):
     """
-    These is an optional dependecies that shows a progress bar for some
+    These is an optional dependency that shows a progress bar for some
     of the functions, e.g. loading.
 
     install this dependency with `pip install tqdm`
@@ -51,9 +51,9 @@ def tqdm(iteratable, *args, **kwargs):
     """
     try:
         from tqdm import tqdm as iterator
-        return iterator(iteratable, *args, **kwargs)
+        return iterator(iterable, *args, **kwargs)
     except:
-        return iteratable
+        return iterable
 
 
 def _parse_date(string):
@@ -435,7 +435,7 @@ def write_edf(edf_file, signals, signal_headers, header=None, digital=False,
     assert file_type in [-1, 0, 1, 2, 3], \
         'file_type must be in range -1, 3'
 
-    # copy objects to prevent accidential changes to mutable objects
+    # copy objects to prevent accidental changes to mutable objects
     header = deepcopy(header)
     signal_headers = deepcopy(signal_headers)
 

--- a/setup.py
+++ b/setup.py
@@ -260,7 +260,7 @@ class develop_build_clib(develop):
 
 if __name__ == '__main__':
 
-    # Rewrite the version file everytime
+    # Rewrite the version file every time
     write_version_py()
     if USE_CYTHON:
             ext_modules = cythonize(ext_modules, compiler_directives=cythonize_opts)

--- a/util/refguide_check.py
+++ b/util/refguide_check.py
@@ -513,7 +513,7 @@ class Checker(doctest.OutputChecker):
 
     def _do_check(self, want, got):
         # This should be done exactly as written to correctly handle all of
-        # numpy-comparable objects, strings, and heterogenous tuples
+        # numpy-comparable objects, strings, and heterogeneous tuples
         try:
             if want == got:
                 return True


### PR DESCRIPTION
I have left out typos in `pyedflib/_extensions/c/edflib.h`, these should be and have been fixed upstream.