### PR TITLE
3.7 <= Python <= 3.11

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [36, 37, 38, 39, 310]
+        python: [36, 37, 38, 39, 310, 311]
         include:
           - os: ubuntu-latest
             arch: aarch64

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [36, 37, 38, 39, 310, 311]
+        python: [37, 38, 39, 310, 311]
         include:
           - os: ubuntu-latest
             arch: aarch64

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -39,7 +39,7 @@ Requirements
 
 ``PyEDFlib`` requires:
 
-- Python_ >=3.5
+- Python_ >=3.7
 - Numpy_ >= 1.9.1
 
 Download

--- a/setup.py
+++ b/setup.py
@@ -292,6 +292,7 @@ if __name__ == '__main__':
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
+            "Programming Language :: Python :: 3.11",
             "Topic :: Software Development :: Libraries :: Python Modules"
         ],
         platforms=["Windows", "Linux", "Solaris", "Mac OS-X", "Unix"],

--- a/setup.py
+++ b/setup.py
@@ -286,8 +286,6 @@ if __name__ == '__main__':
             "Programming Language :: C",
             "Programming Language :: Python",
             "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.5",
-            "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
- [README.rst](https://github.com/holgern/pyedflib/blob/master/README.rst) already states
  > pyEDFlib can be used with [Python](http://python.org/) >=3.7.
- Python 3.5 [reached EOL](https://devguide.python.org/versions/) in 2020.
- Python 3.6 [reached EOL](https://devguide.python.org/versions/) in 2021.
- Python 3.5 is not (easily) available in CI runners.