### PR TITLE
Remove dependency on the deprecated np.testing.Tester

### DIFF
--- a/pyedflib/__init__.py
+++ b/pyedflib/__init__.py
@@ -14,7 +14,6 @@ from . import highlevel
 from . import data
 
 from pyedflib.version import version as __version__
-from numpy.testing import Tester
 
 __all__ = [s for s in dir() if not s.startswith('_')]
 try:
@@ -23,6 +22,3 @@ try:
     del s
 except NameError:
     pass
-
-
-test = Tester().test


### PR DESCRIPTION
Hi! Today's release of [numpy v1.25.0](https://github.com/numpy/numpy/releases/tag/v1.25.0) removed `numpy.testing.Tester` (see numpy/numpy#23041). This causes the corresponding import in pyedflib's in [`__init__.py`](https://github.com/holgern/pyedflib/blob/022bbe9c4d9ab18fa57106bec22fd513ccb857fd/pyedflib/__init__.py#L17) to fail. I think this is a remnant of pyedflib using nose for testing so it can likely be removed. If you prefer to keep it, I'd like to suggest introducing an upper bound for the required numpy version.