### PR TITLE
add python 3.8 for wheel building

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -45,7 +45,8 @@ jobs:
 
       # Used to host cibuildwheel
       - uses: actions/setup-python@v4
-
+        with:
+          python-version: '3.8'
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel
 


### PR DESCRIPTION
`setup-python@v4` requires to specify a Python version. 