### PR TITLE
Avoid deprecated sample_rate in our own code

### DIFF
--- a/pyedflib/edfwriter.py
+++ b/pyedflib/edfwriter.py
@@ -171,19 +171,6 @@ class EdfWriter:
             edflib.FILETYPE_EDFPLUS
             edflib.FILETYPE_BDFPLUS
         n_channels is the number of channels without the annotation channel
-
-        channel_info should be a
-        list of dicts, one for each channel in the data. Each dict needs
-        these values:
-
-            'label' : channel label (string, <= 16 characters, must be unique)
-            'dimension' : physical dimension (e.g., mV) (string, <= 8 characters)
-            'sample_rate' : sample frequency in hertz (int). Deprecated: use 'sample_frequency' instead.
-            'sample_frequency' : number of samples per record (int)
-            'physical_max' : maximum physical value (float)
-            'physical_min' : minimum physical value (float)
-            'digital_max' : maximum digital value (int, -2**15 <= x < 2**15)
-            'digital_min' : minimum digital value (int, -2**15 <= x < 2**15)
         """
         self.path = file_name
         self.file_type = file_type
@@ -205,13 +192,15 @@ class EdfWriter:
         self.sample_buffer = []
         for i in np.arange(self.n_channels):
             if self.file_type == FILETYPE_BDFPLUS or self.file_type == FILETYPE_BDF:
-                self.channels.append({'label': f'ch{i}', 'dimension': 'mV', 'sample_rate': 100,
-                                      'sample_frequency': None, 'physical_max': 1.0, 'physical_min': -1.0,
+                self.channels.append({'label': f'ch{i}', 'dimension': 'mV',
+                                      'sample_frequency': 100,
+                                      'physical_max': 1.0, 'physical_min': -1.0,
                                       'digital_max': 8388607,'digital_min': -8388608,
                                       'prefilter': '', 'transducer': ''})
             elif self.file_type == FILETYPE_EDFPLUS or self.file_type == FILETYPE_EDF:
-                self.channels.append({'label': f'ch{i}', 'dimension': 'mV', 'sample_rate': 100,
-                                      'sample_frequency': None, 'physical_max': 1.0, 'physical_min': -1.0,
+                self.channels.append({'label': f'ch{i}', 'dimension': 'mV',
+                                      'sample_frequency': 100,
+                                      'physical_max': 1.0, 'physical_min': -1.0,
                                       'digital_max': 32767, 'digital_min': -32768,
                                       'prefilter': '', 'transducer': ''})
 

--- a/pyedflib/edfwriter.py
+++ b/pyedflib/edfwriter.py
@@ -314,6 +314,19 @@ class EdfWriter:
             'digital_max' : maximum digital value (int, -2**15 <= x < 2**15)
             'digital_min' : minimum digital value (int, -2**15 <= x < 2**15)
         """
+        try:
+            sample_rate = channel_info.pop('sample_rate')
+        except KeyError:
+            pass
+        else:
+            if 'sample_frequency' in channel_info:
+                if sample_rate != channel_info['sample_frequency']:
+                    warnings.warn("The 'sample_rate' parameter is deprecated. "
+                                  "Please use 'sample_frequency' instead.",
+                                  DeprecationWarning)
+            else:
+                channel_info['sample_frequency'] = sample_rate
+
         if edfsignal < 0 or edfsignal > self.n_channels:
             raise ChannelDoesNotExist(edfsignal)
         self.channels[edfsignal].update(channel_info)

--- a/pyedflib/highlevel.py
+++ b/pyedflib/highlevel.py
@@ -239,10 +239,14 @@ def make_signal_header(label, dimension='uV', sample_rate=256, sample_frequency=
         a signal header that can be used to save a channel to an EDF.
 
     """
+    if sample_frequency is None:
+        sample_frequency = sample_rate
+    elif sample_rate != 256 and sample_rate != sample_frequency:
+        warnings.warn("The 'sample_rate' parameter is deprecated. Please use "
+                      "'sample_frequency' instead.", DeprecationWarning)
 
     signal_header = {'label': label,
                'dimension': dimension,
-               'sample_rate': sample_rate,
                'sample_frequency': sample_frequency,
                'physical_min': physical_min,
                'physical_max': physical_max,


### PR DESCRIPTION
Fixes #198.

At least I think it should. Let's wait for feedback.

The idea is that we should be **able to read** files with `sample_rate` for backwards compatibility, but **not write** files with `sample_rate`. Of course, this means that older versions of pyedflib won't be able to read files produced with newer versions of pyedeflib. Hence, I guess, the CI failure:
```
            for shead1, shead2 in zip(signal_headers1, signal_headers2):
                # When only 'sample_rate' is present, we use its value to write
                # the file, ignoring 'sample_frequency', which means that when
                # we read it back only the 'sample_rate' value is present.
>               self.assertDictEqual({**shead1, 'sample_frequency': shead1['sample_rate']},
                                     shead2)
E               KeyError: 'sample_rate'
```

An alternative would be to output warnings when reading files, **only** when the values of `sample_rate` and  `sample_frequency` are different.

Thoughts?