### PR TITLE
More documentation for "sample frequency"

### DIFF
--- a/pyedflib/edfreader.py
+++ b/pyedflib/edfreader.py
@@ -370,11 +370,10 @@ class EdfReader(CyEdfReader):
 
     def getBirthdate(self, string=True):
         """
-        Returns the birthdate as string object
+        Returns the birthdate as a string.
 
         Parameters
         ----------
-        None
 
         Examples
         --------
@@ -393,7 +392,9 @@ class EdfReader(CyEdfReader):
 
     def getSampleFrequencies(self):
         """
-        Returns  samplefrequencies of all signals.
+        Returns the number of samples for all channels.
+
+        The effective sample frequency is samplefrequency / duration.
 
         Parameters
         ----------
@@ -413,7 +414,9 @@ class EdfReader(CyEdfReader):
 
     def getSampleFrequency(self, chn):
         """
-        Returns the samplefrequency of signal edfsignal.
+        Returns the number of samples in given channel.
+
+        The effective sample frequency is samplefrequency / duration.
 
         Parameters
         ----------


### PR DESCRIPTION
It turns out "sample frequency" is actually the number of samples per channel/signal in EDFlib:
https://www.teuniz.net/edflib/doc/edflib_8h.html#a11d03849cecc17a2599125a1a102b69e

We inherit this strange definition, and need to explain it.

Fixes #199.