### PR TITLE
hotfix Cython<3, else can't install

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 nose
-cython
+cython<3.0
 numpy
 pytest
 dateparser

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,6 @@ requires = [
     "setuptools",
     "wheel",
 	"oldest-supported-numpy",
-    "cython"
+    "cython<3.0"
 ]
 build-backend = "setuptools.build_meta"

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,7 +4,7 @@ wheel
 flake8
 nose
 coverage
-cython
+cython<3.0
 numpy
 pytest
 dateparser


### PR DESCRIPTION
With newest Cython version 3.0, something with finding the modules is broken. Until  we have time to dive for a solution, I propose this hotfix to set Cython<3. As the Build is done in its own env, this should have no impact on the base env that we are installing to, ie. no side-effects


See #233 