### PR TITLE
Remove wheel from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
     "setuptools",
-    "wheel",
 	"oldest-supported-numpy",
     "cython<3.0"
 ]


### PR DESCRIPTION
This dependency is automatically provided by `setuptools`(see https://github.com/pypa/setuptools/commit/f7d30a9529378cf69054b5176249e5457aaf640a).