### PR TITLE
Add macOS ARM64 wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -56,6 +56,7 @@ jobs:
         env:
           # Disable  building PyPy wheels
           CIBW_SKIP: "pp* cp312*i686"
+          CIBW_ARCHS_MACOS: "x86_64 arm64"
           CIBW_PRERELEASE_PYTHONS: False
 
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
I noticed that macOS ARM64 wheels are missing, so hopefully this PR will add them. Is there a way to test if this works on cibuildwheel?