### PR TITLE
Support Cython 3

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 nose
-cython<3.0
+cython
 numpy
 pytest
 dateparser

--- a/pyedflib/_extensions/_pyedflib.pyx
+++ b/pyedflib/_extensions/_pyedflib.pyx
@@ -21,7 +21,7 @@ __all__ = ['lib_version', 'CyEdfReader', 'set_patientcode', 'set_starttime_subse
 import locale
 import os
 import warnings
-cimport c_edf
+from . cimport c_edf
 cimport cpython
 import numpy as np
 cimport numpy as np

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,6 @@
 requires = [
     "setuptools",
 	"oldest-supported-numpy",
-    "cython<3.0"
+    "cython"
 ]
 build-backend = "setuptools.build_meta"

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,7 +4,7 @@ wheel
 flake8
 nose
 coverage
-cython<3.0
+cython
 numpy
 pytest
 dateparser


### PR DESCRIPTION
Fix a relative `cimport` and revert the commit that pinned `cython<3.0`.