### PR TITLE
Converted assert of phys_min and phys_max into warnings

### DIFF
--- a/pyedflib/highlevel.py
+++ b/pyedflib/highlevel.py
@@ -531,12 +531,12 @@ def write_edf(
             assert pmin != pmax, \
             f'physical_min {pmin} should be different from physical_max {pmax}'
         else: # only warning, as this will not lead to clipping
-            assert pmin<=sig.min(), \
-            'phys_min is {}, but signal_min is {} ' \
-            'for channel {}'.format(pmin, sig.min(), label)
-            assert pmax>=sig.max(), \
-            'phys_max is {}, but signal_max is {} ' \
-            'for channel {}'.format(pmax, sig.max(), label)
+            if pmin > sig.min():
+                warnings.warn(f'phys_min is {pmin}, but signal_min is {sig.min()} ' \
+                'for channel {label}')
+            if pmax < sig.max():
+                warnings.warn(f'phys_max is {pmax}, but signal_max is {sig.max()} ' \
+                'for channel {label}')
 
     # get annotations, in format [[timepoint, duration, description], [...]]
     annotations = header.get('annotations', [])

--- a/pyedflib/highlevel.py
+++ b/pyedflib/highlevel.py
@@ -533,10 +533,10 @@ def write_edf(
         else: # only warning, as this will not lead to clipping
             if pmin > sig.min():
                 warnings.warn(f'phys_min is {pmin}, but signal_min is {sig.min()} ' \
-                'for channel {label}')
+                'for channel {label}', category=UserWarning)
             if pmax < sig.max():
                 warnings.warn(f'phys_max is {pmax}, but signal_max is {sig.max()} ' \
-                'for channel {label}')
+                'for channel {label}', category=UserWarning)
 
     # get annotations, in format [[timepoint, duration, description], [...]]
     annotations = header.get('annotations', [])

--- a/pyedflib/tests/test_highlevel.py
+++ b/pyedflib/tests/test_highlevel.py
@@ -234,7 +234,7 @@ class TestHighLevel(unittest.TestCase):
         sheaders = [highlevel.make_signal_header('ch1', sample_frequency=256)]
         sheaders[0]['physical_min'] = -200
         sheaders[0]['physical_max'] = 200
-        with self.assertRaises(AssertionError):
+        with self.assertWarnsRegex(expected_warning=UserWarning, expected_regex="phys_min is.*"):
             highlevel.write_edf(self.edfplus_data_file, signals, sheaders, digital=False)
 
 

--- a/pyedflib/tests/test_highlevel.py
+++ b/pyedflib/tests/test_highlevel.py
@@ -222,20 +222,36 @@ class TestHighLevel(unittest.TestCase):
     def test_assertion_dmindmax(self):
 
         # test digital and dmin wrong
-        signals =[np.random.randint(-2048, 2048, 256*60).astype(np.int32)]
+        signals =[np.random.randint(-2048, 2048, 256*60).astype(np.int16)]
         sheaders = [highlevel.make_signal_header('ch1', sample_frequency=256)]
         sheaders[0]['digital_min'] = -128
         sheaders[0]['digital_max'] = 128
         with self.assertRaises(AssertionError):
             highlevel.write_edf(self.edfplus_data_file, signals, sheaders, digital=True)
 
-        # test pmin wrong
-        signals = [np.random.randint(-2048, 2048, 256*60)]
+        # test physical min and max wrong
+        signals = [np.random.randint(-2048, 2048, 256*60).astype(np.int16)]
         sheaders = [highlevel.make_signal_header('ch1', sample_frequency=256)]
         sheaders[0]['physical_min'] = -200
         sheaders[0]['physical_max'] = 200
+        
+        # a large difference between phys min and values should result in error
+        with self.assertRaises(AssertionError):
+            highlevel.write_edf(self.edfplus_data_file, signals, sheaders, digital=False)
+        
+        # A small roundoff difference between phys min and values should result in warning
+        # edf_accuracy is calculated as: max_signals / digital_max or min_signals / digital_min
+        #   (whichever is smallest). digital_max = 2^16 / 2
+        edf_accuracy = min([max(signals[0])/sheaders[0]['digital_max'], min(signals[0])/sheaders[0]['digital_min']]).astype(np.float16)
+
+        sheaders[0]['physical_min'] = min(signals[0]) - edf_accuracy
+        sheaders[0]['physical_max'] = max(signals[0]) + edf_accuracy
+
         with self.assertWarnsRegex(expected_warning=UserWarning, expected_regex="phys_min is.*"):
             highlevel.write_edf(self.edfplus_data_file, signals, sheaders, digital=False)
+        
+        # It would be nice to doublecheck the written data in the files here.
+        # However, the (rather inaccurate) data rescaling of EDF files makes this tricky.
 
 
     def test_read_write_accented(self):

--- a/pyedflib/tests/test_highlevel.py
+++ b/pyedflib/tests/test_highlevel.py
@@ -244,8 +244,8 @@ class TestHighLevel(unittest.TestCase):
         #   (whichever is smallest). digital_max = 2^16 / 2
         edf_accuracy = min([max(signals[0])/sheaders[0]['digital_max'], min(signals[0])/sheaders[0]['digital_min']]).astype(np.float16)
 
-        sheaders[0]['physical_min'] = min(signals[0]) - edf_accuracy
-        sheaders[0]['physical_max'] = max(signals[0]) + edf_accuracy
+        sheaders[0]['physical_min'] = min(signals[0]) + 0.999 * edf_accuracy
+        sheaders[0]['physical_max'] = max(signals[0]) - 0.999 * edf_accuracy
 
         with self.assertWarnsRegex(expected_warning=UserWarning, expected_regex="phys_min is.*"):
             highlevel.write_edf(self.edfplus_data_file, signals, sheaders, digital=False)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 import os
 import subprocess
 import sys
-from distutils.sysconfig import get_python_inc
+import sysconfig
 from functools import partial
 
 import setuptools
@@ -219,7 +219,7 @@ if os.environ.get("CYTHON_TRACE"):
 # C files must be built once only for coverage to work
 c_lib = ('c_edf',{'sources': sources,
                  'depends': headers,
-                 'include_dirs': [make_ext_path("c"), get_python_inc()],
+                 'include_dirs': [make_ext_path("c"), sysconfig.get_path('include')],
                  'macros': c_macros,})
 
 ext_modules = [
@@ -270,7 +270,7 @@ class develop_build_clib(develop):
             setuptools.bootstrap_install_from = None
 
         # create an .egg-link in the installation dir, pointing to our egg
-        from distutils import log
+        from setuptools import log
         log.info("Creating %s (link to %s)", self.egg_link, self.egg_base)
         if not self.dry_run:
             with open(self.egg_link, "w") as f:


### PR DESCRIPTION
Converted assert's into warnings. 

Reason:
in many cases, storing an edf file fails because of roundoff errors: e.g. `phys_min -3565.82 vs. signal_min 3565.8200000000000006` will fail in write_edf (but shouldn't)