### PR TITLE
Deprecate sample_rate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-2019, windows-latest, macos-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,13 +9,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-2019, windows-latest, macos-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
-        exclude:  # Python < v3.8 does not support Apple Silicon ARM64.
-          - python-version: "3.7"
-            os: macos-latest
-        include:  # So run those legacy versions on Intel CPUs.
-          - python-version: "3.7"
-            os: macos-13
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+
     steps:
     - uses: actions/checkout@v3
     - name: Setup Python

--- a/pyedflib/_extensions/_pyedflib.pyx
+++ b/pyedflib/_extensions/_pyedflib.pyx
@@ -555,12 +555,11 @@ def set_equipment(handle, equipment):
 def set_samples_per_record(handle, edfsignal, smp_per_record ):
     """
     int set_samples_per_record(int handle, int edfsignal, int smp_per_record )
-
-    sets how many samples are in each record for this signal.
-    this is not the sampling frequency (Hz), unless record_duration=1
-    The sample frequency is calculated by smp_per_record/record_duration.
-    The function call to the C library is therefore slightly mislabeled
     """
+    # sets how many samples are in each record for this signal.
+    # this is not the sampling frequency (Hz), unless record_duration=1
+    # The sample frequency is calculated by smp_per_record/record_duration.
+    # The function call to the C library is therefore slightly mislabeled
     return c_edf.edf_set_samplefrequency(handle, edfsignal, smp_per_record)
 
 def set_admincode(handle, admincode):

--- a/pyedflib/_extensions/_pyedflib.pyx
+++ b/pyedflib/_extensions/_pyedflib.pyx
@@ -123,7 +123,9 @@ cdef class CyEdfReader:
     Note that edflib.c is encapsulated so there is no direct access to the file
     from here unless I add a raw interface or something
 
-    EDF/BDF+ files are arranged into N signals sampled at rate Fs. The data is actually stored in chunks called    "datarecords" which have a file specific size.
+    EDF/BDF+ files are arranged into N signals sampled at rate Fs.
+    The data is actually stored in chunks called  "datarecords" which have a
+    file specific size.
 
     A typical way to use this to read an EEG file would be to choose a certain
     number of seconds per page to display. Then figureout how many data records
@@ -554,9 +556,10 @@ def set_samples_per_record(handle, edfsignal, smp_per_record ):
     """
     int set_samples_per_record(int handle, int edfsignal, int smp_per_record )
 
-    sets how many samples are in the record for this signal.
-    this is not the sampling frequency (Hz), (which is calculated by
-    by smp_per_record/record_duration).
+    sets how many samples are in each record for this signal.
+    this is not the sampling frequency (Hz), unless record_duration=1
+    The sample frequency is calculated by smp_per_record/record_duration.
+    The function call to the C library is therefore slightly mislabeled
     """
     return c_edf.edf_set_samplefrequency(handle, edfsignal, smp_per_record)
 

--- a/pyedflib/edfreader.py
+++ b/pyedflib/edfreader.py
@@ -206,7 +206,6 @@ class EdfReader(CyEdfReader):
         return {
             "label": self.getLabel(chn),
             "dimension": self.getPhysicalDimension(chn),
-            "sample_rate": self.getSampleFrequency(chn),  # backwards compatibility
             "sample_frequency": self.getSampleFrequency(chn),
             "physical_max": self.getPhysicalMaximum(chn),
             "physical_min": self.getPhysicalMinimum(chn),

--- a/pyedflib/edfwriter.py
+++ b/pyedflib/edfwriter.py
@@ -381,7 +381,7 @@ class EdfWriter:
         for ch in self.channels:
             # raise exception, can be removed in later release
             if 'sample_rate' in ch:
-                raise ValueError('Use of `sample_rate` is deprecated, use `sample_frequency` instead')
+                raise FutureWarning('Use of `sample_rate` is deprecated, use `sample_frequency` instead')
 
         sample_freqs = [ch['sample_frequency'] for ch in self.channels]
         if not self._enforce_record_duration and not any([f is None for f in sample_freqs]):
@@ -620,7 +620,7 @@ class EdfWriter:
         This function is NOT REQUIRED but can be called after opening a file
         in writemode and before the first sample write action. This function
         can be used when you want to use a samplefrequency which is not an
-        integer. For example, if you want to use a samplefreq of 0.5 Hz, set
+        integer. For example, if you want to use a sample frequency of 0.5 Hz, set
         the samplefrequency to 5 Hz and the datarecord duration to 10 seconds.
         Do not use this function, except when absolutely necessary!
         """

--- a/pyedflib/edfwriter.py
+++ b/pyedflib/edfwriter.py
@@ -1039,9 +1039,6 @@ class EdfWriter:
         record (i.e. window/block of data) with the given record duration.
         """
         fs = self.channels[ch_idx]['sample_frequency']
-        # if fs is None:
-        #     print('NONE')
-        #     return None
 
         record_duration = self.record_duration
         smp_per_record = fs*record_duration

--- a/pyedflib/edfwriter.py
+++ b/pyedflib/edfwriter.py
@@ -10,6 +10,9 @@ import warnings
 from datetime import date, datetime
 from types import TracebackType
 from typing import Any, Union, Optional, List, Dict, Type
+import math
+from functools import reduce
+from fractions import Fraction
 
 import numpy as np
 
@@ -182,6 +185,89 @@ def gender2int(gender: Union[int, str, None]) -> Optional[int]:
     return sex2int(gender)
 
 
+def _calculate_record_duration(freqs, max_str_len=8, max_val=60):
+    """
+    Finds a 'record duration' X in (0, max_val] such that for each freq in freqs:
+      * freq * X is an integer (or freq is zero / already integer)
+      * len(str(X).rstrip('0').rstrip('.')) <= max_str_len
+
+    Returns:
+        float: A suitable multiplier X.
+    Raises:
+        ValueError: if no suitable multiplier is found.
+    """
+    # Convert input to float just in case
+    freqs = [float(f) for f in freqs]
+
+    # Ignore frequencies that are 0.0 or already integral — these don't impose constraints
+    nonint_freqs = []
+    for f in freqs:
+        if f == 0.0:
+            continue
+        # If nearly an integer, treat it as integer
+        #   or do an exact check if you prefer: if f.is_integer():
+        if abs(f - round(f)) < 1e-12:
+            continue
+        nonint_freqs.append(f)
+
+    # If there's no non-integer frequency, X=1 is trivially fine
+    if not nonint_freqs:
+        return 1.0
+
+    # Convert each frequency to a fraction with a bounded denominator
+    frac_list = [Fraction(f).limit_denominator(10_000_000) for f in nonint_freqs]
+
+    # Compute the LCM of all denominators
+    def lcm(a, b):
+        return abs(a * b) // math.gcd(a, b)
+
+    denominators = [fr.denominator for fr in frac_list]
+    L = reduce(lcm, denominators, 1)
+
+    # For each freq_i = nᵢ / dᵢ, define Mᵢ = L / dᵢ
+    # We want X = L / d for some d that divides EVERY (nᵢ × Mᵢ).
+    numerators = [fr.numerator for fr in frac_list]
+    Ms = [L // fr.denominator for fr in frac_list]
+
+    # G = gcd of all (nᵢ × Mᵢ)
+    gcd_val = 0
+    for n, M in zip(numerators, Ms):
+        gcd_val = math.gcd(gcd_val, n * M)
+
+    # Edge case: if gcd_val == 0, just return 1.0 to avoid dividing by zero
+    if gcd_val == 0:
+        return 1.0
+
+    # Enumerate all divisors of gcd_val in ascending order
+    def all_divisors(num):
+        divs = []
+        i = 1
+        while i * i <= num:
+            if num % i == 0:
+                divs.append(i)
+                if i != num // i:
+                    divs.append(num // i)
+            i += 1
+        return sorted(divs)
+
+    divisors = all_divisors(gcd_val)
+
+    # For each divisor d, form X = L / d and see if it's <= max_val and short enough
+    for d in divisors:
+        candidate = L / d
+        if candidate <= max_val:
+            # Build a short string
+            c_str = str(candidate).rstrip('0').rstrip('.')
+            if len(c_str) <= max_str_len:
+                return float(candidate)
+
+    raise ValueError(
+        f"No suitable record_duration (≤ {max_val}) found with ≤ {max_str_len} ASCII chars "
+        f"for frequencies: {freqs}"
+    )
+
+
+
 class ChannelDoesNotExist(Exception):
     def __init__(self, value: Any) -> None:
         self.parameter = value
@@ -252,12 +338,12 @@ class EdfWriter:
         self.sample_buffer: List[List] = []
         for i in np.arange(self.n_channels):
             if self.file_type == FILETYPE_BDFPLUS or self.file_type == FILETYPE_BDF:
-                self.channels.append({'label': f'ch{i}', 'dimension': 'mV', 'sample_frequency': None,
+                self.channels.append({'label': f'ch{i}', 'dimension': 'mV', 'sample_frequency': 100,
                                       'physical_max': 1.0, 'physical_min': -1.0,
                                       'digital_max': 8388607,'digital_min': -8388608,
                                       'prefilter': '', 'transducer': ''})
             elif self.file_type == FILETYPE_EDFPLUS or self.file_type == FILETYPE_EDF:
-                self.channels.append({'label': f'ch{i}', 'dimension': 'mV', 'sample_frequency': None,
+                self.channels.append({'label': f'ch{i}', 'dimension': 'mV', 'sample_frequency': 100,
                                       'physical_max': 1.0, 'physical_min': -1.0,
                                       'digital_max': 32767, 'digital_min': -32768,
                                       'prefilter': '', 'transducer': ''})
@@ -291,7 +377,17 @@ class EdfWriter:
         # the channels, we need to find a common denominator so that all sample
         # frequencies can be represented accurately.
         # this can be overwritten by explicitly calling setDatarecordDuration
-        self._calculate_optimal_record_duration()
+
+        for ch in self.channels:
+            # raise exception, can be removed in later release
+            if 'sample_rate' in ch:
+                raise ValueError('Use of `sample_rate` is deprecated, use `sample_frequency` instead')
+
+        sample_freqs = [ch['sample_frequency'] for ch in self.channels]
+        if not self._enforce_record_duration and not any([f is None for f in sample_freqs]):
+            assert all([isinstance(f, (float, int)) for f in sample_freqs]), \
+                f'{sample_freqs=} contains non int/float'
+            self.record_duration = _calculate_record_duration(sample_freqs)
 
         set_technician(self.handle, du(self.technician))
         set_recording_additional(self.handle, du(self.recording_additional))
@@ -329,6 +425,8 @@ class EdfWriter:
             set_transducer(self.handle, i, du(self.channels[i]['transducer']))
             set_prefilter(self.handle, i, du(self.channels[i]['prefilter']))
 
+
+
     def setHeader(self, fileHeader: Dict[str, Union[str, float, int, None]]) -> None:
         """
         Sets the file header
@@ -354,7 +452,6 @@ class EdfWriter:
 
             'label' : channel label (string, <= 16 characters, must be unique)
             'dimension' : physical dimension (e.g., mV) (string, <= 8 characters)
-            'sample_rate' : sample frequency in hertz (int). Deprecated: use 'sample_frequency' instead.
             'sample_frequency' : number of samples per record (int)
             'physical_max' : maximum physical value (float)
             'physical_min' : minimum physical value (float)
@@ -378,8 +475,6 @@ class EdfWriter:
                           channel label (string, <= 16 characters, must be unique)
                 'dimension' : str
                           physical dimension (e.g., mV) (string, <= 8 characters)
-                'sample_rate' :
-                          sample frequency in hertz (int). Deprecated: use 'sample_frequency' instead.
                 'sample_frequency' : int
                           number of samples per record
                 'physical_max' : float
@@ -525,10 +620,11 @@ class EdfWriter:
         This function is NOT REQUIRED but can be called after opening a file
         in writemode and before the first sample write action. This function
         can be used when you want to use a samplefrequency which is not an
-        integer. For example, if you want to use a samplerate of 0.5 Hz, set
+        integer. For example, if you want to use a samplefreq of 0.5 Hz, set
         the samplefrequency to 5 Hz and the datarecord duration to 10 seconds.
         Do not use this function, except when absolutely necessary!
         """
+        warnings.warn('Forcing a specific record_duration might alter calculated sample_frequencies when reading the file')
         self._enforce_record_duration = True
         self.record_duration = record_duration
         self.update_header()
@@ -836,12 +932,6 @@ class EdfWriter:
 
         All parameters must be already written into the bdf/edf-file.
         """
-        there_are_blank_sample_frequencies = any([channel.get('sample_frequency') is None
-                                                 for channel in self.channels])
-        if there_are_blank_sample_frequencies:
-            warnings.warn("The 'sample_rate' parameter is deprecated. Please use "
-                          "'sample_frequency' instead.", DeprecationWarning)
-
         if (len(data_list)) == 0:
             raise WrongInputSize('Data list is empty')
         if (len(data_list) != len(self.channels)):
@@ -949,7 +1039,9 @@ class EdfWriter:
         record (i.e. window/block of data) with the given record duration.
         """
         fs = self.channels[ch_idx]['sample_frequency']
-        if fs is None: return None
+        # if fs is None:
+        #     print('NONE')
+        #     return None
 
         record_duration = self.record_duration
         smp_per_record = fs*record_duration
@@ -959,32 +1051,3 @@ class EdfWriter:
                           f'smp_per_record={smp_per_record}, record_duration={record_duration} seconds,' +
                           f'calculated sample_frequency will be {np.round(smp_per_record)/record_duration}')
         return int(np.round(smp_per_record))
-
-
-    def _calculate_optimal_record_duration(self) -> None:
-        """
-        calculate optimal denominator (record duration in seconds)
-        for all sample frequencies such that smp_per_record is an integer
-        for all channels.
-
-        If all sampling frequencies are integers, this will simply be 1.
-        """
-        if self._enforce_record_duration: return
-        allint = lambda int_list: all([n==int(n) for n in int_list])
-        all_fs = [self.channels[i]['sample_frequency'] for i,_ in enumerate(self.channels)]
-
-        # calculate the optimal record duration to represent all frequencies.
-        # this is achieved when fs*duration=int, i.e. the number of samples
-        # in one data record can be represented by an int (smp_per_record)
-        # if all sampling frequencies are ints, this will be simply 1
-        # for now this brute force solution should cover 99% of cases.
-        # TODO: optimize this process
-
-        record_duration = 0
-        for i in range(1, 60):
-            if allint([x*i for x in all_fs]):
-                record_duration = i
-                break
-        assert record_duration>0, f'cannot accurately represent sampling frequencies with data record durations between 1-60s: {all_fs}'
-        assert record_duration<=60, 'record duration must be below 60 seconds'
-        self.record_duration = record_duration

--- a/pyedflib/highlevel.py
+++ b/pyedflib/highlevel.py
@@ -503,7 +503,7 @@ def write_edf(
     # check dmin, dmax and pmin, pmax dont exceed signal min/max
     for sig, shead in zip(signals, signal_headers):
         if 'sample_rate' in shead:
-            raise ValueError('Use of `sample_rate` is deprecated, use `sample_frequency` instead')
+            raise FutureWarning('Use of `sample_rate` is deprecated, use `sample_frequency` instead')
 
         dmin, dmax = shead['digital_min'], shead['digital_max']
         pmin, pmax = shead['physical_min'], shead['physical_max']

--- a/pyedflib/tests/test_edfreader.py
+++ b/pyedflib/tests/test_edfreader.py
@@ -308,7 +308,7 @@ class TestEdfReader(unittest.TestCase):
 
     def test_BdfReader_Read_accented_file(self):
         sample_frequency = 100
-        channel_info = {'label': 'test_label', 'dimension': 'mV', 'sample_rate': 256,
+        channel_info = {'label': 'test_label', 'dimension': 'mV',
                         'sample_frequency': sample_frequency, 'physical_max': 1.0, 'physical_min': -1.0,
                         'digital_max': 8388607, 'digital_min': -8388608,
                         'prefilter': 'pre1', 'transducer': 'trans1'}
@@ -351,7 +351,7 @@ class TestEdfReader(unittest.TestCase):
         # now we create a file that is not EDF/BDF compliant
         # this should raise an OSError and not a FileNotFoundError
         with self.assertRaises(OSError) as cm:
-            channel_info = {'label': 'test_label', 'dimension': 'mV', 'sample_rate': 256,
+            channel_info = {'label': 'test_label', 'dimension': 'mV',
                             'sample_frequency': 100, 'physical_max': 1.0, 'physical_min': -1.0,
                             'digital_max': 8388607, 'digital_min': -8388608,
                             'prefilter': 'pre1', 'transducer': 'trans1'}

--- a/pyedflib/tests/test_edfreader.py
+++ b/pyedflib/tests/test_edfreader.py
@@ -260,9 +260,10 @@ class TestEdfReader(unittest.TestCase):
 
         del f
 
+
     def test_EdfReader_Check_Size(self):
         sample_frequency = 100
-        channel_info = {'label': 'test_label', 'dimension': 'mV', 'sample_rate': 256,
+        channel_info = {'label': 'test_label', 'dimension': 'mV',
                         'sample_frequency': sample_frequency, 'physical_max': 1.0, 'physical_min': -1.0,
                         'digital_max': 8388607, 'digital_min': -8388608,
                         'prefilter': 'pre1', 'transducer': 'trans1'}
@@ -276,19 +277,18 @@ class TestEdfReader(unittest.TestCase):
 
         f = pyedflib.EdfReader(self.bdf_broken_file, pyedflib.READ_ALL_ANNOTATIONS, pyedflib.DO_NOT_CHECK_FILE_SIZE)
         np.testing.assert_equal(f.getTechnician(), 'tec1')
-
         np.testing.assert_equal(f.getLabel(0), 'test_label')
         np.testing.assert_equal(f.getPhysicalDimension(0), 'mV')
         np.testing.assert_equal(f.getPrefilter(0), 'pre1')
         np.testing.assert_equal(f.getTransducer(0), 'trans1')
         np.testing.assert_equal(f.getSampleFrequency(0), sample_frequency)
 
-        # When both 'sample_rate' and 'sample_frequency' are present, we write
-        # the file using the latter, which means that when we read it back,
-        # only the 'sample_frequency' value is present.
-        expected_signal_header = {**channel_info, 'sample_rate': sample_frequency}
-        np.testing.assert_equal(f.getSignalHeader(0), expected_signal_header)
-        np.testing.assert_equal(f.getSignalHeaders(), [expected_signal_header])
+        # sample_rate was deprecated, check that it does not appear anymore
+        sheads = f.getSignalHeaders()
+        for shead in sheads:
+            assert not 'sample_rate' in shead
+            assert 'sample_frequency' in shead
+
         del f
 
     def test_EdfReader_Close_file(self):
@@ -327,12 +327,11 @@ class TestEdfReader(unittest.TestCase):
         np.testing.assert_equal(f.getPrefilter(0), 'pre1')
         np.testing.assert_equal(f.getTransducer(0), 'trans1')
 
-        # When both 'sample_rate' and 'sample_frequency' are present, we write
-        # the file using the latter, which means that when we read it back,
-        # only the 'sample_frequency' value is present.
-        expected_signal_header = {**channel_info, 'sample_rate': sample_frequency}
-        np.testing.assert_equal(f.getSignalHeader(0), expected_signal_header)
-        np.testing.assert_equal(f.getSignalHeaders(), [expected_signal_header])
+        # sample_rate was deprecated, check that it does not appear anymore
+        sheads = f.getSignalHeaders()
+        for shead in sheads:
+            assert not 'sample_rate' in shead
+            assert 'sample_frequency' in shead
         del f
 
 

--- a/pyedflib/tests/test_edfwriter.py
+++ b/pyedflib/tests/test_edfwriter.py
@@ -937,7 +937,7 @@ class TestEdfWriter(unittest.TestCase):
 
         f = pyedflib.EdfWriter(self.edf_data_file, channel_count, file_type=pyedflib.FILETYPE_EDF)
         f.setDatarecordDuration(record_duration)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(FutureWarning):
             f.setSignalHeaders([{
                 'sample_rate': sample_rate,
                 **base_signal_header(idx)

--- a/pyedflib/tests/test_highlevel.py
+++ b/pyedflib/tests/test_highlevel.py
@@ -119,11 +119,7 @@ class TestHighLevel(unittest.TestCase):
             self.assertEqual(len(signals2), 5)
             self.assertEqual(len(signals2), len(signal_headers2))
             for shead1, shead2 in zip(signal_headers1, signal_headers2):
-                # When only 'sample_rate' is present, we use its value to write
-                # the file, ignoring 'sample_frequency', which means that when
-                # we read it back only the 'sample_rate' value is present.
-                self.assertDictEqual({**shead1, 'sample_frequency': shead1['sample_rate']},
-                                     shead2)
+                self.assertDictEqual(shead1,  shead2)
             np.testing.assert_allclose(signals, signals2, atol=0.01)
             if file_type in [-1, 1, 3]:
                 self.assertDictEqual(header, header2)
@@ -141,11 +137,8 @@ class TestHighLevel(unittest.TestCase):
             self.assertEqual(len(signals2), len(signal_headers2))
             np.testing.assert_array_equal(signals, signals2)
             for shead1, shead2 in zip(signal_headers1, signal_headers2):
-                # When only 'sample_rate' is present, we use its value to write
-                # the file, ignoring 'sample_frequency', which means that when
-                # we read it back only the 'sample_rate' value is present.
-                self.assertDictEqual({**shead1, 'sample_frequency': shead1['sample_rate']},
-                                     shead2)
+                self.assertDictEqual(shead1,  shead2)
+
             # EDF/BDF header writing does not correctly work yet
             if file_type in [-1, 1, 3]:
                 self.assertDictEqual(header, header2)
@@ -414,6 +407,19 @@ class TestHighLevel(unittest.TestCase):
         highlevel.write_edf(self.edfplus_data_file, signals, signal_headers, header)
         _,_,header3 = highlevel.read_edf(self.edfplus_data_file)
         self.assertEqual(header2['annotations'], header3['annotations'])
+
+    def test_deprecated_sample_rate(self):
+        header = highlevel.make_header(technician='tech', recording_additional='radd',
+                                                patientname='name', patient_additional='padd',
+                                                patientcode='42', equipment='eeg', admincode='420',
+                                                sex='Male', birthdate='05.09.1980')
+        annotations = [[0.01, b'-1', 'begin'],[0.5, b'-1', 'middle'],[10, -1, 'end']]
+        header['annotations'] = annotations
+        signal_headers = highlevel.make_signal_headers(['ch'+str(i) for i in range(3)])
+        signal_headers[0]['sample_rate'] = 256
+        signals = np.random.rand(3, 256*300)*200 #5 minutes of eeg
+        with self.assertRaises(ValueError):
+            highlevel.write_edf(self.edfplus_data_file, signals, signal_headers, header)
 
 
 if __name__ == '__main__':

--- a/pyedflib/tests/test_highlevel.py
+++ b/pyedflib/tests/test_highlevel.py
@@ -418,7 +418,7 @@ class TestHighLevel(unittest.TestCase):
         signal_headers = highlevel.make_signal_headers(['ch'+str(i) for i in range(3)])
         signal_headers[0]['sample_rate'] = 256
         signals = np.random.rand(3, 256*300)*200 #5 minutes of eeg
-        with self.assertRaises(ValueError):
+        with self.assertRaises(FutureWarning):
             highlevel.write_edf(self.edfplus_data_file, signals, signal_headers, header)
 
 


### PR DESCRIPTION
As discussed in https://github.com/holgern/pyedflib/issues/247 , I deprecated `sample_rate` and replaced all of its occurences with `sample_frequency`.

Frequency is usually measured in Hz, which is defined per second and is most consistent with other libraries (e.g. `mne`).

**Summary**
- There are errors raised when users try to use `sample_rate` - this is to ensure everyone finds out about the change without googeling
- I added a new routine to calculate `record_duration` - it should find an optimal value if one exists and let users not worry about the `sample_rate` as it is defined in `edflib` but to simply sey `sample_frequency` and be done
- It's still possible to overwrite the value of `record_duration` if ppl actually need to for obscure reasons

Additionally, needed to deprecate 3.7 for the test suite as it's not available for ubuntu24

fixes #198
closes #247