### PR TITLE
Include more test cases for record_duration

### DIFF
--- a/pyedflib/edfreader.py
+++ b/pyedflib/edfreader.py
@@ -33,7 +33,7 @@ DO_NOT_CHECK_FILE_SIZE = 1
 REPAIR_FILE_SIZE_IF_WRONG = 2
 
 
-def _debug_parse_header(filename: str) -> None:  # pragma: no cover
+def _debug_parse_header(filename: str, printout=True) -> None:  # pragma: no cover
     """
     A debug function that reads a header and outputs everything that
     is contained in the header
@@ -55,8 +55,9 @@ def _debug_parse_header(filename: str) -> None:  # pragma: no cover
         header["record_duration"] = f.read(8).decode()
         header["n_signals"] = f.read(4).decode()
 
-        print("\n##### Header")
-        print(json.dumps(header, indent=2))
+        if printout:
+            print("\n##### Header")
+            print(json.dumps(header, indent=2))
 
         nsigs = int(header["n_signals"])
         label = [f.read(16).decode() for i in range(nsigs)]
@@ -95,8 +96,10 @@ def _debug_parse_header(filename: str) -> None:  # pragma: no cover
         "reserved",
     ]
     sheaders = [{field: values[field][i] for field in fields} for i in range(nsigs)]
-    print("\n##### Signal Headers")
-    print(json.dumps(sheaders, indent=2))
+    if printout:
+        print("\n##### Signal Headers")
+        print(json.dumps(sheaders, indent=2))
+    return header, sheaders
 
 
 class EdfReader(CyEdfReader):

--- a/pyedflib/edfwriter.py
+++ b/pyedflib/edfwriter.py
@@ -257,7 +257,7 @@ def _calculate_record_duration(freqs, max_str_len=8, max_val=60):
         candidate = L / d
         if candidate <= max_val:
             # Build a short string
-            c_str = str(candidate).rstrip('0').rstrip('.')
+            c_str = f'{candidate:f}'.rstrip('0').rstrip('.')
             if len(c_str) <= max_str_len:
                 return float(candidate)
 
@@ -602,7 +602,7 @@ class EdfWriter:
     def setDatarecordDuration(self, record_duration: Union[float, int]) -> None:
         """
         Sets the datarecord duration. The default value is 1 second.
-        The datarecord duration must be in the range 0.00001 to 60 seconds.
+        The datarecord duration must be in the range 0.001 to 60 seconds.
         Usually, the datarecord duration is calculated automatically to
         ensure that all sample frequencies are representable, nevertheless,
         you can overwrite the datarecord duration manually. This can, however,
@@ -626,6 +626,8 @@ class EdfWriter:
         """
         warnings.warn('Forcing a specific record_duration might alter calculated sample_frequencies when reading the file')
         self._enforce_record_duration = True
+        if 0.001 > record_duration or record_duration > 60:
+            raise ValueError('record_duration must be between 0.001 and 60 seconds')
         self.record_duration = record_duration
         self.update_header()
 


### PR DESCRIPTION
Based on #238 and #242 I assessed the recent changes in #268 and improved the changes

- added more test cases for different manual `record_duration`s
- due to the conversion to `long long` we are limited to record durations between 0.001 and 60, which should be fine for most cases
- 