### PR TITLE
Add BufferedEdfWriter for arbitrary-size (streaming) sample blocks

### DIFF
--- a/pyedflib/buffered.py
+++ b/pyedflib/buffered.py
@@ -1,0 +1,82 @@
+"""Buffered EDF/BDF writing for real-time (streaming) acquisition.
+
+Real-time acquisition loops usually read the device in small blocks (for example
+10-100 samples). Passing such sub-record blocks directly to
+:meth:`pyedflib.EdfWriter.writeSamples` makes each call commit a full data record
+padded to length, which silently inflates the file duration and distorts the
+stored signal. :class:`BufferedEdfWriter` wraps an ``EdfWriter`` and accepts
+blocks of arbitrary size, committing a record only once a full record is
+available and padding just the final record on :meth:`close`.
+"""
+
+import numpy as np
+
+__all__ = ["BufferedEdfWriter"]
+
+
+class BufferedEdfWriter:
+    """Accept arbitrary-size sample blocks and commit only complete data records.
+
+    Parameters
+    ----------
+    edf_writer : pyedflib.EdfWriter
+        A writer whose signal headers and data-record duration are already set.
+
+    Examples
+    --------
+    >>> writer = EdfWriter("out.edf", 1)
+    >>> writer.setSignalHeader(0, header)
+    >>> writer.setDatarecordDuration(1.0)
+    >>> bw = BufferedEdfWriter(writer)
+    >>> while acquiring:
+    ...     bw.write_samples([device.read(100)])   # any block size is fine
+    >>> bw.close()
+    """
+
+    def __init__(self, edf_writer):
+        self._w = edf_writer
+        self._n = len(edf_writer.channels)
+        self._rec = [int(edf_writer.get_smp_per_record(i)) for i in range(self._n)]
+        self._buf = [np.array([], dtype=np.float64) for _ in range(self._n)]
+
+    def write_samples(self, data_list):
+        """Append one block per signal; flush every complete data record."""
+        if len(data_list) != self._n:
+            raise ValueError(
+                "expected {} signals, got {}".format(self._n, len(data_list))
+            )
+        for i in range(self._n):
+            self._buf[i] = np.concatenate(
+                [self._buf[i], np.asarray(data_list[i], dtype=np.float64)]
+            )
+        while all(len(self._buf[i]) >= self._rec[i] for i in range(self._n)):
+            record = [
+                np.ascontiguousarray(self._buf[i][: self._rec[i]])
+                for i in range(self._n)
+            ]
+            self._w.writeSamples(record)
+            for i in range(self._n):
+                self._buf[i] = self._buf[i][self._rec[i]:]
+
+    def flush(self, pad_with_last=True):
+        """Write any pending samples, padding the final record.
+
+        The final record is padded with the last acquired value (``pad_with_last``,
+        the default) rather than zero, so that no step discontinuity is introduced.
+        """
+        if all(len(self._buf[i]) == 0 for i in range(self._n)):
+            return
+        record = []
+        for i in range(self._n):
+            b = self._buf[i]
+            if len(b) < self._rec[i]:
+                pad_val = b[-1] if (len(b) and pad_with_last) else 0.0
+                b = np.concatenate([b, np.full(self._rec[i] - len(b), pad_val)])
+            record.append(np.ascontiguousarray(b[: self._rec[i]]))
+            self._buf[i] = np.array([], dtype=np.float64)
+        self._w.writeSamples(record)
+
+    def close(self):
+        """Flush the remainder and close the underlying writer."""
+        self.flush()
+        self._w.close()

--- a/pyedflib/tests/test_buffered.py
+++ b/pyedflib/tests/test_buffered.py
@@ -1,0 +1,73 @@
+import numpy as np
+import pyedflib
+from pyedflib.buffered import BufferedEdfWriter
+
+
+def _header(fs):
+    return dict(
+        label="EMG", dimension="mV", sample_frequency=fs,
+        physical_min=-5, physical_max=5, digital_min=-32768, digital_max=32767,
+        transducer="", prefilter="",
+    )
+
+
+def test_buffered_writer_prevents_inflation(tmp_path):
+    fs = 1000
+    x = np.random.default_rng(0).standard_normal(10 * fs) * 0.1
+    p = str(tmp_path / "buffered.edf")
+
+    w = pyedflib.EdfWriter(p, 1)
+    w.setSignalHeader(0, _header(fs))
+    w.setDatarecordDuration(1.0)
+    bw = BufferedEdfWriter(w)
+    for s in range(0, len(x), 100):        # 100-sample streaming blocks
+        bw.write_samples([x[s:s + 100]])
+    bw.close()
+
+    r = pyedflib.EdfReader(p)
+    duration = r.file_duration
+    back = r.readSignal(0)
+    r.close()
+
+    assert abs(duration - 10.0) < 1e-6      # no inflation
+    rms_ratio = np.sqrt(np.mean(back ** 2)) / np.sqrt(np.mean(x ** 2))
+    assert abs(rms_ratio - 1.0) < 0.02      # amplitude preserved
+
+
+def test_naive_subrecord_blocks_inflate_file(tmp_path):
+    """Documents the behaviour that BufferedEdfWriter avoids."""
+    fs = 1000
+    x = np.random.default_rng(0).standard_normal(10 * fs) * 0.1
+    p = str(tmp_path / "naive.edf")
+
+    w = pyedflib.EdfWriter(p, 1)
+    w.setSignalHeader(0, _header(fs))
+    w.setDatarecordDuration(1.0)
+    for s in range(0, len(x), 100):
+        w.writeSamples([np.ascontiguousarray(x[s:s + 100])])
+    w.close()
+
+    r = pyedflib.EdfReader(p)
+    duration = r.file_duration
+    r.close()
+
+    assert duration == 100.0                # 10x inflation without buffering
+
+
+def test_buffered_writer_multichannel(tmp_path):
+    fs = 1000
+    rng = np.random.default_rng(1)
+    x = [rng.standard_normal(10 * fs) * 0.1 for _ in range(2)]
+    p = str(tmp_path / "buffered_mc.edf")
+
+    w = pyedflib.EdfWriter(p, 2)
+    w.setSignalHeaders([_header(fs), _header(fs)])
+    w.setDatarecordDuration(1.0)
+    bw = BufferedEdfWriter(w)
+    for s in range(0, len(x[0]), 100):
+        bw.write_samples([x[0][s:s + 100], x[1][s:s + 100]])
+    bw.close()
+
+    r = pyedflib.EdfReader(p)
+    assert abs(r.file_duration - 10.0) < 1e-6
+    r.close()


### PR DESCRIPTION
## Summary

Real-time acquisition loops usually read the device in small blocks (for example 10–100 samples). Passing such sub-record blocks directly to `EdfWriter.writeSamples` makes each call commit a full data record padded to length, which silently inflates the file duration and distorts the stored signal (see issue #284). This PR adds an **opt-in** `BufferedEdfWriter` wrapper that accepts blocks of arbitrary size, commits a record only once a full record is available, and pads just the final record (with the last acquired value) on `close()`. It does **not** change `EdfWriter`'s existing behaviour.

## What is included

- `pyedflib/buffered.py` — the `BufferedEdfWriter` class.
- `pyedflib/tests/test_buffered.py` — tests: buffering prevents the file-duration inflation, documents the naive sub-record inflation, and covers the multichannel case.

## Example

```python
import pyedflib
from pyedflib.buffered import BufferedEdfWriter

writer = pyedflib.EdfWriter("out.edf", 1)
writer.setSignalHeader(0, header)
writer.setDatarecordDuration(1.0)

bw = BufferedEdfWriter(writer)
while acquiring:
    bw.write_samples([device.read(100)])   # any block size is fine
bw.close()
```

## Notes

- Fully backward compatible: a new, opt-in class; no change to the existing API.
- If preferred, it could be exported from the top-level package so that `from pyedflib import BufferedEdfWriter` works; happy to add that.
- Closes #284.
