### PR TITLE
Fix ruff RUF059 unused-unpacked-variable complaints

### DIFF
--- a/pyedflib/tests/test_edfreader.py
+++ b/pyedflib/tests/test_edfreader.py
@@ -57,7 +57,7 @@ class TestEdfReader(unittest.TestCase):
             print('cannot open', self.edf_data_file)
             return
 
-        ann_index, ann_duration, ann_text = f.readAnnotations()
+        ann_index, _ann_duration, _ann_text = f.readAnnotations()
         np.testing.assert_almost_equal(ann_index[0], 0)
         np.testing.assert_almost_equal(ann_index[1], 600)
 
@@ -237,7 +237,7 @@ class TestEdfReader(unittest.TestCase):
             print('cannot open', self.edf_data_file)
             return
 
-        ann_index, ann_duration, ann_text = f.readAnnotations()
+        ann_index, _ann_duration, _ann_text = f.readAnnotations()
         np.testing.assert_equal(ann_index.size, 0)
 
         del f
@@ -248,7 +248,7 @@ class TestEdfReader(unittest.TestCase):
             print('cannot open', self.edf_data_file)
             return
 
-        ann_index, ann_duration, ann_text = f.readAnnotations()
+        ann_index, _ann_duration, _ann_text = f.readAnnotations()
         np.testing.assert_almost_equal(ann_index[0], 0)
         np.testing.assert_almost_equal(ann_index[1], 600)
 
@@ -398,7 +398,7 @@ class TestEdfReader(unittest.TestCase):
     def test_read_annotations_utf8(self):
         """properly test for UTF8 reading of existing file"""
         with pyedflib.EdfReader(self.edf_utf8) as f:
-            ann_time, ann_duration, ann_text = f.readAnnotations()
+            _ann_time, _ann_duration, ann_text = f.readAnnotations()
             self.assertEqual(ann_text[2], '中文测试八个字')
 
 

--- a/pyedflib/tests/test_edfwriter.py
+++ b/pyedflib/tests/test_edfwriter.py
@@ -1125,7 +1125,7 @@ class TestEdfWriter(unittest.TestCase):
             f.close()
             del f
 
-            header, sheader = _debug_parse_header(self.edf_data_file, printout=False)
+            header, _sheader = _debug_parse_header(self.edf_data_file, printout=False)
             self.assertEqual(float(header['record_duration']), record_duration)
 
             with pyedflib.EdfReader(self.edf_data_file) as f:

--- a/pyedflib/tests/test_highlevel.py
+++ b/pyedflib/tests/test_highlevel.py
@@ -149,7 +149,7 @@ class TestHighLevel(unittest.TestCase):
         self.assertEqual(header['annotations'], expected)
 
         highlevel.write_edf(self.edfplus_data_file, signals, signal_headers, header)
-        signals2, signal_header2s, header2 = highlevel.read_edf(self.edfplus_data_file)
+        _signals2, _signal_header2s, header2 = highlevel.read_edf(self.edfplus_data_file)
         self.assertEqual(header['annotations'], header2['annotations'])
 
 
@@ -208,7 +208,7 @@ class TestHighLevel(unittest.TestCase):
             shead = highlevel.make_signal_header(f'ch{sfreq}', sample_frequency=sfreq)
             sheaders.append(shead)
         highlevel.write_edf(self.edfplus_data_file, signals, sheaders, digital=True)
-        signals2, sheaders2, _ = highlevel.read_edf(self.edfplus_data_file, digital=True)
+        signals2, _sheaders2, _ = highlevel.read_edf(self.edfplus_data_file, digital=True)
         for s1, s2 in zip(signals, signals2):
             np.testing.assert_allclose(s1, s2)
 
@@ -263,7 +263,7 @@ class TestHighLevel(unittest.TestCase):
         success = highlevel.write_edf_quick(self.edfplus_data_file, signals, sfreq=256)
         self.assertTrue(success)
         shutil.copy(self.edfplus_data_file, self.test_unicode)
-        signals2, _, _ = highlevel.read_edf(self.test_unicode)
+        _signals2, _, _ = highlevel.read_edf(self.test_unicode)
         self.assertTrue(os.path.isfile(self.test_unicode), 'File does not exist')
 
 
@@ -395,13 +395,13 @@ class TestHighLevel(unittest.TestCase):
 
         dropped = highlevel.drop_channels(self.drop_from, to_keep=['ch1', 'ch2'], verbose=True)
 
-        signals2, signal_headers, header = highlevel.read_edf(dropped)
+        signals2, signal_headers, _header = highlevel.read_edf(dropped)
 
         np.testing.assert_allclose(signals[1:3,:], signals2, atol=0.01)
 
         highlevel.drop_channels(self.drop_from, self.drop_from[:-4]+'2.edf',
                                 to_drop=['ch0', 'ch1', 'ch2'])
-        signals2, signal_headers, header = highlevel.read_edf(self.drop_from[:-4]+'2.edf')
+        signals2, signal_headers, _header = highlevel.read_edf(self.drop_from[:-4]+'2.edf')
 
         np.testing.assert_allclose(signals[3:,:], signals2, atol=0.01)
 

--- a/util/authors.py
+++ b/util/authors.py
@@ -206,7 +206,7 @@ class Cmd:
     def read(self, command, *a, **kw):
         p = self._call(command, a, {"stdout": subprocess.PIPE},
                       call=False, **kw)
-        out, err = p.communicate()
+        out, _err = p.communicate()
         if p.returncode != 0:
             raise RuntimeError("%s failed" % self.executable)
         return out

--- a/util/gh_lists.py
+++ b/util/gh_lists.py
@@ -67,7 +67,7 @@ def main():
 
 def get_milestones(getter, project):
     url = f"https://api.github.com/repos/{project}/milestones"
-    raw_data, info = getter.get(url)
+    raw_data, _info = getter.get(url)
     data = json.loads(raw_data)
 
     milestones = {}

--- a/util/refguide_check.py
+++ b/util/refguide_check.py
@@ -556,7 +556,7 @@ def _run_doctests(tests, full_name, verbose, doctest_warnings):
 
         for t in tests:
             t.filename = short_path(t.filename, cwd)
-            fails, successes = runner.run(t, out=out)
+            fails, _successes = runner.run(t, out=out)
             if fails > 0:
                 success = False
     finally:


### PR DESCRIPTION
## Summary
- `ruff check .` reported 15 `RUF059` warnings for tuple-unpack results that are never used
- Prefixed those variables with an underscore (e.g. `signals2, _sheaders2, _ = highlevel.read_edf(...)`) so they're clearly intentional discards
- No behavioral changes

## Test plan
- [x] `ruff check .` passes clean
- [x] `pytest pyedflib/tests/test_edfreader.py pyedflib/tests/test_edfwriter.py pyedflib/tests/test_highlevel.py` — 62 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)