### PR TITLE
Support sub-millisecond record durations via edf_set_micro_datarecord_duration

### DIFF
--- a/pyedflib/_extensions/_pyedflib.pyx
+++ b/pyedflib/_extensions/_pyedflib.pyx
@@ -621,18 +621,16 @@ def set_datarecord_duration(handle, duration):
 
     duration in seconds
     """
-    # from the pyedflib documentation:
-    # > To avoid rounding errors, the library stores some timevalues in variables
-    # > of type long long int. In order not to loose the subsecond precision, all
-    # > timevalues have been multiplied by 10000000. This will limit the
-    # > timeresolution to 100 nanoSeconds. To calculate the amount of seconds,
-    # > divide the timevalue by 10000000 or use the macro EDFLIB_TIME_DIMENSION
-    # > which is declared in edflib.h.
-    #
-    # therefore, we divide by 100, and edflib internally multiplies by 100.
-    # we could also change it in the C file, but better to leave that as is.
-    duration *= EDFLIB_TIME_DIMENSION/100
-    return c_edf.edf_set_datarecord_duration(handle, int(duration))
+    # edf_set_datarecord_duration takes the duration in units of 10 microseconds
+    # and only accepts values between 0.001 and 60 seconds.
+    # edf_set_micro_datarecord_duration takes the duration in units of
+    # 1 microsecond and accepts values between 1 and 9999 microseconds.
+    # dispatch to the micro variant below 10 ms: it covers sub-millisecond
+    # durations and has a 10x finer resolution (1 us instead of 10 us).
+    microseconds = round(duration * 1_000_000)
+    if microseconds < 10_000:
+        return c_edf.edf_set_micro_datarecord_duration(handle, microseconds)
+    return c_edf.edf_set_datarecord_duration(handle, round(duration * EDFLIB_TIME_DIMENSION/100))
 
 def set_number_of_annotation_signals(handle, annot_signals):
     """int edf_set_number_of_annotation_signals(int handle, int annot_signals)"""

--- a/pyedflib/_extensions/c_edf.pxd
+++ b/pyedflib/_extensions/c_edf.pxd
@@ -87,6 +87,7 @@ cdef extern from "c/edflib.h":
     int edf_set_startdatetime(int, int, int, int, int, int, int)
     int edf_set_subsecond_starttime(int, int)
     int edf_set_datarecord_duration(int, int)
+    int edf_set_micro_datarecord_duration(int, int)
     int edf_set_number_of_annotation_signals(int, int)
 
     # new functions in 1.10

--- a/pyedflib/edfwriter.py
+++ b/pyedflib/edfwriter.py
@@ -588,7 +588,9 @@ class EdfWriter:
     def setDatarecordDuration(self, record_duration: Union[float, int]) -> None:
         """
         Sets the datarecord duration. The default value is 1 second.
-        The datarecord duration must be in the range 0.001 to 60 seconds.
+        The datarecord duration must be in the range 0.000001 to 60 seconds.
+        Durations below 10 milliseconds are stored with a resolution of
+        1 microsecond, so they must be an integer multiple of 0.000001.
         Usually, the datarecord duration is calculated automatically to
         ensure that all sample frequencies are representable, nevertheless,
         you can overwrite the datarecord duration manually. This can, however,
@@ -612,8 +614,10 @@ class EdfWriter:
         """
         warnings.warn('Forcing a specific record_duration might alter calculated sample_frequencies when reading the file')
         self._enforce_record_duration = True
-        if 0.001 > record_duration or record_duration > 60:
-            raise ValueError('record_duration must be between 0.001 and 60 seconds')
+        if 1e-6 > record_duration or record_duration > 60:
+            raise ValueError('record_duration must be between 0.000001 and 60 seconds')
+        if record_duration < 0.01 and abs(record_duration * 1e6 - round(record_duration * 1e6)) > 1e-6:
+            raise ValueError('record_durations below 10 ms must be an integer multiple of 1 microsecond')
         self.record_duration = record_duration
         self.update_header()
 

--- a/pyedflib/tests/test_edfwriter.py
+++ b/pyedflib/tests/test_edfwriter.py
@@ -1098,7 +1098,7 @@ class TestEdfWriter(unittest.TestCase):
 
     def test_record_durations(self):
         """use different record durations and look in the raw header if all seems right"""
-        for record_duration in [0.001, 0.01, 0.1, 1, 10, 60]:
+        for record_duration in [0.000001, 0.0001, 0.009999, 0.001, 0.01, 0.1, 1, 10, 60]:
             channel_count = 1
             sample_frequency = 1/record_duration
 
@@ -1133,7 +1133,7 @@ class TestEdfWriter(unittest.TestCase):
                 f.close()
 
 
-        for record_duration in [0.0001,  61]:
+        for record_duration in [0.0000005, 61, 0.0001234567]:
             channel_count = 1
             sample_frequency = 1/record_duration
 


### PR DESCRIPTION
Closes #273

## What

`set_datarecord_duration` (Cython wrapper) now dispatches durations below 10 ms to `edf_set_micro_datarecord_duration`, which takes integer microseconds (1–9999 µs). This enables sub-millisecond data record durations with 1 µs resolution; `edf_set_datarecord_duration` only accepts 0.001–60 s in units of 10 µs.

`setDatarecordDuration` on the writer now accepts 1e-6 to 60 s and validates that sub-10 ms durations are integer multiples of 1 µs (the finest resolution the micro variant can represent).

## Why two C functions exist (answering the question in #273)

`edf_set_micro_datarecord_duration` was added to edflib for high-speed ADCs. Its 9999 µs cap guarantees the duration prints exactly into the EDF header's 8-char ASCII duration field (`0.009999`). The two functions' ranges overlap in 1–10 ms and together cover 1 µs – 60 s seamlessly. The reader needs no changes: durations are already stored as `long long` in 100 ns units.

## Bonus fix

The unit conversion now uses `round()` instead of `int()`: previously `0.009999` s was truncated to `int(999.9)` = 9.99 ms silently.

## Verification

- Round-trip tested writer→reader at 1 µs / 100 µs / 5 ms / 9.999 ms / 10 ms / 1 s / 10 s: header field, read-back duration, and sample frequency all exact.
- `test_record_durations` extended with 1 µs, 100 µs, 9999 µs as valid values and 0.5 µs / 61 s / non-µs-multiple as rejected values.
- Full test suite passes (62 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code), validated by @skjerns 