### PR TITLE
Prevent silent loss of annotations exceeding datarecord capacity

### DIFF
--- a/pyedflib/edfwriter.py
+++ b/pyedflib/edfwriter.py
@@ -339,6 +339,13 @@ class EdfWriter:
         if (self.handle < 0):
             raise OSError(write_errors[self.handle])
         self._enforce_record_duration = False
+        # track how many datarecords and annotations have been written:
+        # each datarecord can only store one annotation per annotation signal,
+        # any excess annotations are silently discarded by the C library,
+        # so we warn about it in close() (see issue #187)
+        self._n_records_written = 0
+        self._channel_write_pos = 0
+        self._n_annotations_written = 0
 
     def update_header(self) -> None:
         """
@@ -622,9 +629,11 @@ class EdfWriter:
         Sets the number of annotation signals. The default value is 1
         This function is optional and can be called only after opening a file in writemode
         and before the first sample write action
-        Normally you don't need to change the default value. Only when the number of annotations
-        you want to write is more than the number of seconds of the duration of the recording, you can use
-        this function to increase the storage space for annotations
+        Normally you don't need to change the default value. Each datarecord
+        can store one annotation per annotation signal, i.e. the total number
+        of annotations the file can hold is
+        `number_of_annotations * number_of_datarecords`. Use this function to
+        increase the storage space for annotations.
         Minimum is 1, maximum is 64
 
         Parameters
@@ -632,6 +641,9 @@ class EdfWriter:
         number_of_annotations : integer
             Sets the number of annotation signals
         """
+        if not 1 <= int(number_of_annotations) <= 64:
+            warnings.warn(f'number_of_annotations must be between 1 and 64, '
+                          f'{number_of_annotations} will be clipped to that range.')
         number_of_annotations = max((min((int(number_of_annotations), 64)), 1))
         self.number_of_annotations = number_of_annotations
         self.update_header()
@@ -868,13 +880,13 @@ class EdfWriter:
 
         All parameters must be already written into the bdf/edf-file.
         """
-        return write_physical_samples(self.handle, data)
+        return self._count_record(write_physical_samples(self.handle, data))
 
     def writeDigitalSamples(self, data: np.ndarray) -> int:
-        return write_digital_samples(self.handle, data)
+        return self._count_record(write_digital_samples(self.handle, data))
 
     def writeDigitalShortSamples(self, data: np.ndarray) -> int:
-        return write_digital_short_samples(self.handle, data)
+        return self._count_record(write_digital_short_samples(self.handle, data))
 
     def blockWritePhysicalSamples(self, data: np.ndarray) -> int:
         """
@@ -896,13 +908,26 @@ class EdfWriter:
 
         All parameters must be already written into the bdf/edf-file.
         """
-        return blockwrite_physical_samples(self.handle, data)
+        return self._count_record(blockwrite_physical_samples(self.handle, data), block=True)
 
     def blockWriteDigitalSamples(self, data: np.ndarray) -> int:
-        return blockwrite_digital_samples(self.handle, data)
+        return self._count_record(blockwrite_digital_samples(self.handle, data), block=True)
 
     def blockWriteDigitalShortSamples(self, data: np.ndarray) -> int:
-        return blockwrite_digital_short_samples(self.handle, data)
+        return self._count_record(blockwrite_digital_short_samples(self.handle, data), block=True)
+
+    def _count_record(self, write_result: int, block: bool = False) -> int:
+        """keep track of the number of datarecords written, which determines
+        how many annotations the file can hold (see close())"""
+        if write_result >= 0:
+            if block:
+                self._n_records_written += 1
+            else:
+                self._channel_write_pos += 1
+                if self._channel_write_pos == self.n_channels:
+                    self._channel_write_pos = 0
+                    self._n_records_written += 1
+        return write_result
 
     def writeSamples(self, data_list: Union[List[np.ndarray], np.ndarray], digital: bool = False) -> None:
         """
@@ -1002,31 +1027,53 @@ class EdfWriter:
 
         if str_format == 'utf_8':
             if duration_in_seconds >= 0:
-                return write_annotation_utf8(self.handle,
-                                             np.round(onset_in_seconds*10000).astype(np.int64),
-                                             np.round(duration_in_seconds*10000).astype(int),
-                                             du(description))
+                res = write_annotation_utf8(self.handle,
+                                            np.round(onset_in_seconds*10000).astype(np.int64),
+                                            np.round(duration_in_seconds*10000).astype(int),
+                                            du(description))
             else:
-                return write_annotation_utf8(self.handle,
-                                             np.round(onset_in_seconds*10000).astype(np.int64),
-                                             -1, du(description))
+                res = write_annotation_utf8(self.handle,
+                                            np.round(onset_in_seconds*10000).astype(np.int64),
+                                            -1, du(description))
         else:
             if duration_in_seconds >= 0:
                 # FIX: description must be bytes. string will fail in u function
-                return write_annotation_latin1(self.handle,
-                                               np.round(onset_in_seconds*10000).astype(np.int64),
-                                               np.round(duration_in_seconds*10000).astype(int), description.encode('latin1'))  # type: ignore
+                res = write_annotation_latin1(self.handle,
+                                              np.round(onset_in_seconds*10000).astype(np.int64),
+                                              np.round(duration_in_seconds*10000).astype(int), description.encode('latin1'))  # type: ignore
             else:
                 # FIX: description must be bytes. string will fail in u function
-                return write_annotation_latin1(self.handle,
-                                               np.round(onset_in_seconds*10000).astype(np.int64),
-                                               -1,
-                                               description.encode('latin1'))  # type: ignore
+                res = write_annotation_latin1(self.handle,
+                                              np.round(onset_in_seconds*10000).astype(np.int64),
+                                              -1,
+                                              description.encode('latin1'))  # type: ignore
+        if res >= 0:
+            self._n_annotations_written += 1
+        return res
 
     def close(self) -> None:
         """
         Closes the file.
         """
+        # each datarecord can store at most one annotation per annotation
+        # signal. Annotations exceeding this capacity are silently discarded
+        # by the C library when the file is closed, so warn about it here.
+        capacity = self._n_records_written * self.number_of_annotations
+        if self._n_records_written > 0 and self._n_annotations_written > capacity:
+            n_lost = self._n_annotations_written - capacity
+            if self.number_of_annotations < 64:
+                advice = ('Increase the number of annotation signals with '
+                          'set_number_of_annotation_signals() before writing '
+                          'any samples.')
+            else:
+                advice = ('The maximum of 64 annotation signals is already '
+                          'used, use a shorter record_duration to increase '
+                          'the number of datarecords.')
+            warnings.warn(f'File can only store {capacity} annotations '
+                          f'({self._n_records_written} datarecords x '
+                          f'{self.number_of_annotations} annotation signals), but '
+                          f'{self._n_annotations_written} were written. The last '
+                          f'{n_lost} annotation(s) will be lost. ' + advice)
         close_file(self.handle)
         self.handle = -1
 

--- a/pyedflib/highlevel.py
+++ b/pyedflib/highlevel.py
@@ -541,6 +541,15 @@ def write_edf(
     with pyedflib.EdfWriter(edf_file, n_channels=n_channels, file_type=file_type) as f:
         f.setSignalHeaders(signal_headers)
         f.setHeader(header)
+        if len(annotations) > 0:
+            # each datarecord can hold at most one annotation per annotation
+            # signal, excess annotations would be silently discarded (#187),
+            # so set the number of annotation signals to fit all of them.
+            smp_per_record = f.get_smp_per_record(0)
+            n_records = int(np.ceil(len(signals[0]) / smp_per_record))
+            n_annot_signals = int(np.ceil(len(annotations) / max(n_records, 1)))
+            if n_annot_signals > 1:
+                f.set_number_of_annotation_signals(n_annot_signals)
         f.writeSamples(signals, digital=digital)
         for annotation in annotations:
             f.writeAnnotation(*annotation)

--- a/pyedflib/tests/test_edfwriter.py
+++ b/pyedflib/tests/test_edfwriter.py
@@ -3,6 +3,7 @@
 
 import gc
 import os
+import warnings
 
 # from numpy.testing import (assert_raises, run_module_suite,
 #                            assert_equal, assert_allclose, assert_almost_equal)
@@ -163,6 +164,37 @@ class TestEdfWriter(unittest.TestCase):
         assert startdate2==startdate, f'write {startdate} != read {startdate2}'
         del f
 
+
+    def test_annotation_overflow_warning(self):
+        # gh-187: annotations exceeding the capacity of
+        # n_datarecords * n_annotation_signals are silently dropped by the
+        # C library, the writer should warn about this on close()
+        def write_file(n_annotations, n_annotation_signals=1):
+            f = pyedflib.EdfWriter(self.edfplus_data_file, 1,
+                                   file_type=pyedflib.FILETYPE_EDFPLUS)
+            f.setSignalHeader(0, self.ch_info_edf)
+            if n_annotation_signals > 1:
+                f.set_number_of_annotation_signals(n_annotation_signals)
+            for _ in range(5):  # 5 datarecords of 1 second
+                f.writePhysicalSamples(np.ones(100) * 0.1)
+            for i in range(n_annotations):
+                f.writeAnnotation(i * 0.1, -1, f'annot_{i}')
+            f.close()
+
+        # more annotations than datarecords -> warning
+        with self.assertWarns(UserWarning) as cm:
+            write_file(n_annotations=8)
+        self.assertIn('3 annotation(s) will be lost', str(cm.warning))
+
+        # enough annotation signals -> no warning
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            write_file(n_annotations=8, n_annotation_signals=2)
+        self.assertEqual([str(w.message) for w in caught], [])
+
+        # and the file with 2 annotation signals must contain all annotations
+        with pyedflib.EdfReader(self.edfplus_data_file) as f:
+            self.assertEqual(f.annotations_in_file, 8)
 
     def test_subsecond_annotation(self):
         f = pyedflib.EdfWriter(self.bdfplus_data_file, 1,

--- a/pyedflib/tests/test_edfwriter.py
+++ b/pyedflib/tests/test_edfwriter.py
@@ -196,6 +196,42 @@ class TestEdfWriter(unittest.TestCase):
         with pyedflib.EdfReader(self.edfplus_data_file) as f:
             self.assertEqual(f.annotations_in_file, 8)
 
+    def test_set_number_of_annotation_signals(self):
+        # gh-187: manually increasing the number of annotation signals must
+        # actually increase the annotation capacity of the file
+        n_records = 5           # 5 datarecords of 1 second
+        n_annotation_signals = 10
+        n_annotations = 45      # > 5 records, <= 5 records * 10 signals
+
+        f = pyedflib.EdfWriter(self.edfplus_data_file, 1,
+                               file_type=pyedflib.FILETYPE_EDFPLUS)
+        f.setSignalHeader(0, self.ch_info_edf)
+        f.set_number_of_annotation_signals(n_annotation_signals)
+        for _ in range(n_records):
+            f.writePhysicalSamples(np.ones(100) * 0.1)
+        for i in range(n_annotations):
+            f.writeAnnotation(round(i * 0.1, 1), 0.5, f'annot_{i}')
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            f.close()
+        self.assertEqual([str(w.message) for w in caught], [])
+
+        # the file header must contain one label per annotation signal
+        with open(self.edfplus_data_file, 'rb') as fh:
+            header = fh.read(256 * (1 + 1 + n_annotation_signals))
+        self.assertEqual(header.count(b'EDF Annotations'), n_annotation_signals)
+
+        # all annotations must be read back with correct onset/duration/text
+        with pyedflib.EdfReader(self.edfplus_data_file) as f:
+            self.assertEqual(f.annotations_in_file, n_annotations)
+            onsets, durations, texts = f.readAnnotations()
+        order = np.argsort(onsets)
+        np.testing.assert_allclose(onsets[order],
+                                   [round(i * 0.1, 1) for i in range(n_annotations)])
+        np.testing.assert_allclose(durations.astype(float)[order], [0.5] * n_annotations)
+        self.assertEqual([texts[i] for i in order],
+                         [f'annot_{i}' for i in range(n_annotations)])
+
     def test_subsecond_annotation(self):
         f = pyedflib.EdfWriter(self.bdfplus_data_file, 1,
                                file_type=pyedflib.FILETYPE_BDFPLUS)

--- a/pyedflib/tests/test_highlevel.py
+++ b/pyedflib/tests/test_highlevel.py
@@ -152,6 +152,29 @@ class TestHighLevel(unittest.TestCase):
         _signals2, _signal_header2s, header2 = highlevel.read_edf(self.edfplus_data_file)
         self.assertEqual(header['annotations'], header2['annotations'])
 
+    def test_write_more_annotations_than_datarecords(self):
+        # gh-187: more annotations than datarecords were silently dropped.
+        # write_edf should scale the number of annotation signals accordingly
+        sfreq = 256
+        seconds = 60
+        n_annotations = 350
+        signals = np.random.rand(2, sfreq*seconds)
+        signal_headers = highlevel.make_signal_headers(
+            ['ch1', 'ch2'], sample_frequency=sfreq,
+            physical_min=-1, physical_max=1)
+        annotations = [[round(i*seconds/n_annotations, 4), -1, f'marker_{i}']
+                       for i in range(n_annotations)]
+        header = highlevel.make_header()
+        header['annotations'] = annotations
+
+        highlevel.write_edf(self.edfplus_data_file, signals, signal_headers,
+                            header)
+        _, _, header2 = highlevel.read_edf(self.edfplus_data_file)
+        read_annotations = sorted(header2['annotations'])
+        self.assertEqual(len(read_annotations), n_annotations)
+        np.testing.assert_allclose([a[0] for a in read_annotations],
+                                   sorted(a[0] for a in annotations),
+                                   atol=1e-4)
 
     def test_quick_write(self):
         signals = np.random.randint(-2048, 2048, [3, 256*60])


### PR DESCRIPTION
Closes #187

## Problem

An EDF+/BDF+ file can store at most **one annotation per annotation signal per datarecord**. At `edfclose_file`, the C library distributes queued annotations sequentially across the records' annotation channels and silently discards everything beyond `n_datarecords × n_annotation_signals`. With the default 1 annotation signal and 1 s records, 60 s of data holds only 60 annotations — exactly the behavior reported in #187 (350 markers in 1 minute, most lost without any error).

## Fix

- **`highlevel.write_edf`** now computes the number of datarecords upfront and automatically raises the number of annotation signals (`ceil(n_annotations / n_records)`, up to the edflib maximum of 64) so all annotations from the header fit. The reporter's exact scenario (350 annotations / 60 s) now round-trips losslessly.
- **`EdfWriter`** tracks datarecords and annotations written and warns on `close()` when annotations will be lost, stating how many and how to avoid it (more annotation signals, or shorter record duration if already at 64).
- **`set_number_of_annotation_signals`** warns when the requested value is clipped to 1–64 instead of clipping silently, and its docstring now explains the capacity rule.

## Verification

- New test `test_write_more_annotations_than_datarecords` (highlevel round-trip of 350 annotations in 60 s, onsets verified).
- New test `test_annotation_overflow_warning` (warning fires with correct count; no warning when capacity suffices; file with 2 annotation signals retains all 8 annotations).
- Full test suite passes (64 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified by @skjerns 