### PR TITLE
Add pad_with option to control padding of the final data record

### DIFF
--- a/pyedflib/edfwriter.py
+++ b/pyedflib/edfwriter.py
@@ -286,7 +286,8 @@ class EdfWriter:
         self.close()
 
     def __init__(self, file_name: str, n_channels: int, file_type: int = FILETYPE_EDFPLUS,
-                 buffered: bool = False) -> None:
+                 buffered: bool = False,
+                 pad_with: Union[int, float, str] = 0) -> None:
         """Initialises an EDF file at file_name.
         file_type is one of
             edflib.FILETYPE_EDFPLUS
@@ -296,10 +297,18 @@ class EdfWriter:
         If buffered is True, writeSamples() accepts blocks of arbitrary size
         (e.g. small chunks from a real-time acquisition loop): samples are
         buffered and a data record is only committed to file once a full
-        record is available. The last, incomplete record is zero-padded and
+        record is available. The last, incomplete record is padded and
         written on close(). With the default buffered=False, every call to
         writeSamples() commits all passed data, padding the last record to
         full length.
+
+        pad_with controls the value used to pad an incomplete last record
+        (buffered mode only): a number (default 0), or the string 'last' to
+        repeat the last sample of each signal, which avoids a step
+        discontinuity at the end of the recording. The value is interpreted
+        in the same domain as the buffered samples, i.e. as a physical value
+        when writeSamples() was called with digital=False, and as a digital
+        value when digital=True.
 
         channel_info should be a
         list of dicts, one for each channel in the data. Each dict needs
@@ -330,6 +339,7 @@ class EdfWriter:
         self.number_of_annotations = 1 if file_type in [FILETYPE_EDFPLUS, FILETYPE_BDFPLUS] else 0
         self.n_channels = n_channels
         self.buffered = buffered
+        self.pad_with = pad_with
         self._buffered_digital: Optional[bool] = None
         self.channels: List[Dict[str, Union[str, int, float, None]]] = []
         self.sample_buffer: List[np.ndarray] = [np.array([]) for _ in range(n_channels)]
@@ -355,6 +365,10 @@ class EdfWriter:
         self._n_records_written = 0
         self._channel_write_pos = 0
         self._n_annotations_written = 0
+        if not (isinstance(pad_with, (int, float)) and not isinstance(pad_with, bool)) \
+                and pad_with != 'last':
+            raise ValueError("pad_with must be a number or 'last', "
+                             "got {!r}".format(pad_with))
 
     def update_header(self) -> None:
         """
@@ -959,7 +973,7 @@ class EdfWriter:
         If the writer was created with buffered=True, data blocks of arbitrary
         size are accepted: samples are buffered internally and only complete
         data records are committed to file. The remainder is written (padded
-        with zeros) when close() is called.
+        according to `pad_with`) when close() is called.
 
         All parameters must be already written into the bdf/edf-file.
         """
@@ -1122,15 +1136,20 @@ class EdfWriter:
     def _flush_sample_buffer(self) -> None:
         """
         Writes buffered leftover samples (buffered=True) as one final data
-        record, zero-padded to full record length.
+        record, padded to full record length according to `pad_with`.
         """
         if all(len(buf) == 0 for buf in self.sample_buffer):
             return
         digital = bool(self._buffered_digital)
+        dtype = np.int32 if digital else np.float64
         for i in range(len(self.sample_buffer)):
             smp_per_record = self.get_smp_per_record(i)
-            lastSamples = np.zeros(smp_per_record, dtype=np.int32 if digital else None)
             buf = self.sample_buffer[i][:smp_per_record]
+            if self.pad_with == 'last':
+                pad_value = buf[-1] if len(buf) > 0 else 0
+            else:
+                pad_value = self.pad_with
+            lastSamples = np.full(smp_per_record, pad_value, dtype=dtype)
             lastSamples[:len(buf)] = buf
             if digital:
                 success = self.writeDigitalSamples(lastSamples)

--- a/pyedflib/edfwriter.py
+++ b/pyedflib/edfwriter.py
@@ -328,10 +328,10 @@ class EdfWriter:
         if isinstance(pad_with, str):
             if pad_with != 'last':
                 raise ValueError("pad_with must be a number or 'last', "
-                                 "got {!r}".format(pad_with))
+                                 f"got {pad_with!r}")
         elif isinstance(pad_with, bool) or not isinstance(pad_with, numbers.Number):
             raise ValueError("pad_with must be a number or 'last', "
-                             "got {!r}".format(pad_with))
+                             f"got {pad_with!r}")
 
         self.path = file_name
         self.file_type = file_type
@@ -1005,7 +1005,7 @@ class EdfWriter:
         if digital and not isinstance(self.pad_with, str) \
                 and not isinstance(self.pad_with, (int, np.integer)):
             raise TypeError('Digital = True requires an integer pad_with, '
-                            'got {!r}'.format(self.pad_with))
+                            f'got {self.pad_with!r}')
 
         # remember the most recent sample of each channel for pad_with='last'
         for i in range(len(data_list)):
@@ -1080,8 +1080,8 @@ class EdfWriter:
                     lim = ('digital_min', 'digital_max') if digital else ('physical_min', 'physical_max')
                     low, high = self.channels[i][lim[0]], self.channels[i][lim[1]]
                     if not low <= pad_value <= high:
-                        warnings.warn('pad_with={} is outside the range of channel {} '
-                                      '({}...{}) and will be clipped'.format(pad_value, i, low, high))
+                        warnings.warn(f'pad_with={pad_value} is outside the range of '
+                                      f'channel {i} ({low}...{high}) and will be clipped')
                 lastSamples = np.full(smp_per_record[i], pad_value,
                                       dtype=np.int32 if digital else np.float64)
                 lastSamples[:lastSampleInd] = data_list[i][-lastSampleInd:]
@@ -1190,8 +1190,8 @@ class EdfWriter:
                 lim = ('digital_min', 'digital_max') if digital else ('physical_min', 'physical_max')
                 low, high = self.channels[i][lim[0]], self.channels[i][lim[1]]
                 if not low <= pad_value <= high:
-                    warnings.warn('pad_with={} is outside the range of channel {} '
-                                  '({}...{}) and will be clipped'.format(pad_value, i, low, high))
+                    warnings.warn(f'pad_with={pad_value} is outside the range of '
+                                  f'channel {i} ({low}...{high}) and will be clipped')
             lastSamples = np.full(smp_per_record, pad_value, dtype=dtype)
             lastSamples[:len(buf)] = buf
             if digital:

--- a/pyedflib/edfwriter.py
+++ b/pyedflib/edfwriter.py
@@ -1018,7 +1018,7 @@ class EdfWriter:
             elif self._buffered_digital != digital:
                 raise TypeError('Cannot mix digital and physical samples in '
                                 'buffered mode (previous calls used digital='
-                                '{})'.format(self._buffered_digital))
+                                f'{self._buffered_digital})')
             # prepend samples left over from previous writeSamples() calls
             if any(len(buf) > 0 for buf in self.sample_buffer):
                 data_list = [np.concatenate([buf, data]) if len(buf) > 0 else data

--- a/pyedflib/edfwriter.py
+++ b/pyedflib/edfwriter.py
@@ -1008,9 +1008,9 @@ class EdfWriter:
                             f'got {self.pad_with!r}')
 
         # remember the most recent sample of each channel for pad_with='last'
-        for i in range(len(data_list)):
-            if len(data_list[i]) > 0:
-                self._last_sample[i] = data_list[i][-1]
+        for i, channel in enumerate(data_list):
+            if len(channel) > 0:
+                self._last_sample[i] = channel[-1]
 
         if self.buffered:
             if self._buffered_digital is None:

--- a/pyedflib/edfwriter.py
+++ b/pyedflib/edfwriter.py
@@ -966,6 +966,25 @@ class EdfWriter:
                     self._n_records_written += 1
         return write_result
 
+    def _get_pad_value(self, i: int, digital: bool) -> Union[int, float]:
+        """
+        Returns the value used to pad channel ``i`` to a full data record.
+
+        For ``pad_with='last'`` this is the channel's most recently written
+        sample; otherwise it is the configured ``pad_with`` value, which is
+        warned about (and later clipped by edflib) if it falls outside the
+        channel's physical/digital range.
+        """
+        if self.pad_with == 'last':
+            return self._last_sample[i]
+        pad_value = self.pad_with
+        lim = ('digital_min', 'digital_max') if digital else ('physical_min', 'physical_max')
+        low, high = self.channels[i][lim[0]], self.channels[i][lim[1]]
+        if not low <= pad_value <= high:
+            warnings.warn(f'pad_with={pad_value} is outside the range of '
+                          f'channel {i} ({low}...{high}) and will be clipped')
+        return pad_value
+
     def writeSamples(self, data_list: Union[List[np.ndarray], np.ndarray], digital: bool = False) -> None:
         """
         Writes physical samples (uV, mA, Ohm) from data belonging to all signals
@@ -1073,15 +1092,7 @@ class EdfWriter:
             lastSampleInd = int(np.max(data_list[i].shape) - ind[i])
             lastSampleInd = int(np.min((lastSampleInd, smp_per_record[i])))
             if lastSampleInd > 0:
-                if self.pad_with == 'last':
-                    pad_value = self._last_sample[i]
-                else:
-                    pad_value = self.pad_with
-                    lim = ('digital_min', 'digital_max') if digital else ('physical_min', 'physical_max')
-                    low, high = self.channels[i][lim[0]], self.channels[i][lim[1]]
-                    if not low <= pad_value <= high:
-                        warnings.warn(f'pad_with={pad_value} is outside the range of '
-                                      f'channel {i} ({low}...{high}) and will be clipped')
+                pad_value = self._get_pad_value(i, digital)
                 lastSamples = np.full(smp_per_record[i], pad_value,
                                       dtype=np.int32 if digital else np.float64)
                 lastSamples[:lastSampleInd] = data_list[i][-lastSampleInd:]
@@ -1181,17 +1192,10 @@ class EdfWriter:
         for i in range(len(self.sample_buffer)):
             smp_per_record = self.get_smp_per_record(i)
             buf = self.sample_buffer[i][:smp_per_record]
-            if self.pad_with == 'last':
-                # the last sample of this channel may already have been written
-                # to file, so it is not necessarily still in sample_buffer
-                pad_value = self._last_sample[i]
-            else:
-                pad_value = self.pad_with
-                lim = ('digital_min', 'digital_max') if digital else ('physical_min', 'physical_max')
-                low, high = self.channels[i][lim[0]], self.channels[i][lim[1]]
-                if not low <= pad_value <= high:
-                    warnings.warn(f'pad_with={pad_value} is outside the range of '
-                                  f'channel {i} ({low}...{high}) and will be clipped')
+            # for pad_with='last' the last sample of this channel may already
+            # have been written to file, so it is not necessarily still in
+            # sample_buffer; _get_pad_value reads it from self._last_sample
+            pad_value = self._get_pad_value(i, digital)
             lastSamples = np.full(smp_per_record, pad_value, dtype=dtype)
             lastSamples[:len(buf)] = buf
             if digital:

--- a/pyedflib/edfwriter.py
+++ b/pyedflib/edfwriter.py
@@ -10,6 +10,7 @@ from datetime import date, datetime
 from types import TracebackType
 from typing import Any, Union, Optional, List, Dict, Type
 import math
+import numbers
 from functools import reduce
 from fractions import Fraction
 
@@ -302,13 +303,13 @@ class EdfWriter:
         writeSamples() commits all passed data, padding the last record to
         full length.
 
-        pad_with controls the value used to pad an incomplete last record
-        (buffered mode only): a number (default 0), or the string 'last' to
-        repeat the last sample of each signal, which avoids a step
-        discontinuity at the end of the recording. The value is interpreted
-        in the same domain as the buffered samples, i.e. as a physical value
-        when writeSamples() was called with digital=False, and as a digital
-        value when digital=True.
+        pad_with controls the value used to pad an incomplete last record:
+        a number (default 0), or the string 'last' to repeat the last sample
+        of each signal, which avoids a step discontinuity at the end of the
+        recording. The value is interpreted in the same domain as the written
+        samples, i.e. as a physical value when writeSamples() was called with
+        digital=False, and as a digital value when digital=True; in the
+        latter case pad_with must be an integer.
 
         channel_info should be a
         list of dicts, one for each channel in the data. Each dict needs
@@ -322,6 +323,16 @@ class EdfWriter:
             'digital_max' : maximum digital value (int, -2**15 <= x < 2**15)
             'digital_min' : minimum digital value (int, -2**15 <= x < 2**15)
         """
+        # validate before opening the file, so that a bad argument does not
+        # leave a stray empty file behind
+        if isinstance(pad_with, str):
+            if pad_with != 'last':
+                raise ValueError("pad_with must be a number or 'last', "
+                                 "got {!r}".format(pad_with))
+        elif isinstance(pad_with, bool) or not isinstance(pad_with, numbers.Number):
+            raise ValueError("pad_with must be a number or 'last', "
+                             "got {!r}".format(pad_with))
+
         self.path = file_name
         self.file_type = file_type
         self.patient_name = ''
@@ -343,6 +354,9 @@ class EdfWriter:
         self._buffered_digital: Optional[bool] = None
         self.channels: List[Dict[str, Union[str, int, float, None]]] = []
         self.sample_buffer: List[np.ndarray] = [np.array([]) for _ in range(n_channels)]
+        # last sample handed to writeSamples() per channel, used by
+        # pad_with='last' when a channel has no leftover samples of its own
+        self._last_sample: List[Union[int, float]] = [0 for _ in range(n_channels)]
         for i in np.arange(self.n_channels):
             if self.file_type == FILETYPE_BDFPLUS or self.file_type == FILETYPE_BDF:
                 self.channels.append({'label': f'ch{i}', 'dimension': 'mV', 'sample_frequency': 100,
@@ -365,10 +379,6 @@ class EdfWriter:
         self._n_records_written = 0
         self._channel_write_pos = 0
         self._n_annotations_written = 0
-        if not (isinstance(pad_with, (int, float)) and not isinstance(pad_with, bool)) \
-                and pad_with != 'last':
-            raise ValueError("pad_with must be a number or 'last', "
-                             "got {!r}".format(pad_with))
 
     def update_header(self) -> None:
         """
@@ -992,6 +1002,16 @@ class EdfWriter:
         if digital and any(not np.issubdtype(a.dtype, np.integer) for a in data_list):
             raise TypeError('Digital = True requires all signals in int')
 
+        if digital and not isinstance(self.pad_with, str) \
+                and not isinstance(self.pad_with, (int, np.integer)):
+            raise TypeError('Digital = True requires an integer pad_with, '
+                            'got {!r}'.format(self.pad_with))
+
+        # remember the most recent sample of each channel for pad_with='last'
+        for i in range(len(data_list)):
+            if len(data_list[i]) > 0:
+                self._last_sample[i] = data_list[i][-1]
+
         if self.buffered:
             if self._buffered_digital is None:
                 self._buffered_digital = digital
@@ -1044,16 +1064,26 @@ class EdfWriter:
 
         if self.buffered:
             # keep the incomplete remainder for the next call; it is written
-            # out (zero-padded) on close()
+            # out (padded according to pad_with) on close()
             self.sample_buffer = [np.ascontiguousarray(data_list[i][int(ind[i]):])
                                   for i in range(len(data_list))]
             return
 
         for i in np.arange(len(data_list)):
-            lastSamples = np.zeros(smp_per_record[i], dtype=np.int32 if digital else None)
             lastSampleInd = int(np.max(data_list[i].shape) - ind[i])
             lastSampleInd = int(np.min((lastSampleInd, smp_per_record[i])))
             if lastSampleInd > 0:
+                if self.pad_with == 'last':
+                    pad_value = self._last_sample[i]
+                else:
+                    pad_value = self.pad_with
+                    lim = ('digital_min', 'digital_max') if digital else ('physical_min', 'physical_max')
+                    low, high = self.channels[i][lim[0]], self.channels[i][lim[1]]
+                    if not low <= pad_value <= high:
+                        warnings.warn('pad_with={} is outside the range of channel {} '
+                                      '({}...{}) and will be clipped'.format(pad_value, i, low, high))
+                lastSamples = np.full(smp_per_record[i], pad_value,
+                                      dtype=np.int32 if digital else np.float64)
                 lastSamples[:lastSampleInd] = data_list[i][-lastSampleInd:]
                 if digital:
                     success = self.writeDigitalSamples(lastSamples)
@@ -1106,9 +1136,15 @@ class EdfWriter:
         Closes the file.
 
         If the writer was created with buffered=True, any samples still held
-        in the buffer are written as a final, zero-padded data record.
+        in the buffer are written as a final data record, padded according to
+        the `pad_with` parameter.
         """
-        if self.buffered and self.handle >= 0:
+        # __init__ may have raised before the file was opened, in which case
+        # __del__ still calls close() on a partially constructed object
+        if getattr(self, 'handle', -1) < 0:
+            return
+
+        if self.buffered:
             self._flush_sample_buffer()
 
         # each datarecord can store at most one annotation per annotation
@@ -1146,9 +1182,16 @@ class EdfWriter:
             smp_per_record = self.get_smp_per_record(i)
             buf = self.sample_buffer[i][:smp_per_record]
             if self.pad_with == 'last':
-                pad_value = buf[-1] if len(buf) > 0 else 0
+                # the last sample of this channel may already have been written
+                # to file, so it is not necessarily still in sample_buffer
+                pad_value = self._last_sample[i]
             else:
                 pad_value = self.pad_with
+                lim = ('digital_min', 'digital_max') if digital else ('physical_min', 'physical_max')
+                low, high = self.channels[i][lim[0]], self.channels[i][lim[1]]
+                if not low <= pad_value <= high:
+                    warnings.warn('pad_with={} is outside the range of channel {} '
+                                  '({}...{}) and will be clipped'.format(pad_value, i, low, high))
             lastSamples = np.full(smp_per_record, pad_value, dtype=dtype)
             lastSamples[:len(buf)] = buf
             if digital:

--- a/pyedflib/tests/test_edfwriter.py
+++ b/pyedflib/tests/test_edfwriter.py
@@ -1416,6 +1416,85 @@ class TestEdfWriter(unittest.TestCase):
         filename = os.path.join(self.data_dir, 'tmp_buffered_pad_invalid.edf')
         with self.assertRaises(ValueError):
             pyedflib.EdfWriter(filename, 1, buffered=True, pad_with='bogus')
+        # a rejected argument must not leave a half-created file behind
+        self.assertFalse(os.path.exists(filename))
+
+    def test_pad_with_applies_without_buffering(self):
+        """pad_with also controls padding on the regular (unbuffered) path."""
+        fs = 100
+        x = np.full(int(2.5 * fs), 3.0)
+        filename = os.path.join(self.data_dir, 'tmp_pad_unbuffered.edf')
+
+        f = pyedflib.EdfWriter(filename, 1, pad_with='last')
+        f.setSignalHeader(0, self._buffered_ch_info(fs))
+        f.writeSamples([x])
+        f.close()
+
+        f = pyedflib.EdfReader(filename)
+        back = f.readSignal(0)
+        f.close()
+
+        np.testing.assert_allclose(back, 3.0, atol=1e-3)  # no step back to 0
+
+    def test_pad_with_last_uses_already_written_sample(self):
+        """A channel whose buffer is empty pads with its last written sample.
+
+        With differing sample frequencies one channel can end exactly on a
+        record boundary while another still has leftover samples. The padding
+        for the former must not fall back to zero.
+        """
+        filename = os.path.join(self.data_dir, 'tmp_pad_mixed_fs.edf')
+
+        f = pyedflib.EdfWriter(filename, 2, buffered=True, pad_with='last')
+        f.setSignalHeaders([self._buffered_ch_info(100),
+                            self._buffered_ch_info(10)])
+        # ch0 keeps 5 leftover samples, ch1 is consumed exactly
+        f.writeSamples([np.full(105, 3.0), np.full(10, 4.0)])
+        f.close()
+
+        f = pyedflib.EdfReader(filename)
+        ch0, ch1 = f.readSignal(0), f.readSignal(1)
+        f.close()
+
+        np.testing.assert_allclose(ch0, 3.0, atol=1e-3)
+        np.testing.assert_allclose(ch1, 4.0, atol=1e-3)
+
+    def test_pad_with_accepts_numpy_scalars(self):
+        """pad_with=signal[-1] (a numpy scalar) must be accepted."""
+        filename = os.path.join(self.data_dir, 'tmp_pad_numpy_scalar.edf')
+        for value in (np.float64(1.5), np.float32(1.5), np.int32(2)):
+            f = pyedflib.EdfWriter(filename, 1, buffered=True, pad_with=value)
+            f.close()
+        with self.assertRaises(ValueError):
+            pyedflib.EdfWriter(filename, 1, buffered=True, pad_with=True)
+
+    def test_pad_with_digital_requires_int(self):
+        """A fractional pad value would be silently truncated when digital."""
+        fs = 100
+        filename = os.path.join(self.data_dir, 'tmp_pad_digital_float.edf')
+
+        f = pyedflib.EdfWriter(filename, 1, buffered=True, pad_with=2.7)
+        f.setSignalHeader(0, self._buffered_ch_info(fs))
+        with self.assertRaises(TypeError):
+            f.writeSamples([np.full(150, 100, dtype=np.int32)], digital=True)
+        f.close()
+
+    def test_pad_with_out_of_range_warns(self):
+        fs = 100
+        filename = os.path.join(self.data_dir, 'tmp_pad_out_of_range.edf')
+
+        f = pyedflib.EdfWriter(filename, 1, buffered=True, pad_with=1000.0)
+        f.setSignalHeader(0, self._buffered_ch_info(fs))
+        f.writeSamples([np.full(150, 1.0)])
+        with self.assertWarns(UserWarning):
+            f.close()
+
+    def test_close_on_partially_constructed_writer(self):
+        """__del__ must not raise if __init__ failed before opening the file."""
+        filename = os.path.join(self.data_dir, 'tmp_partial.edf')
+        with self.assertRaises(ValueError):
+            pyedflib.EdfWriter(filename, 1, pad_with='bogus')
+        gc.collect()  # triggers __del__ -> close() on the dead object
 
 
 if __name__ == '__main__':

--- a/pyedflib/tests/test_edfwriter.py
+++ b/pyedflib/tests/test_edfwriter.py
@@ -1354,6 +1354,69 @@ class TestEdfWriter(unittest.TestCase):
         f.close()
         np.testing.assert_allclose(back, x, atol=1e-3)
 
+    def test_buffered_writer_pad_with_last(self):
+        """pad_with='last' repeats the last sample instead of zero-padding."""
+        fs = 100
+        x = np.full(int(2.5 * fs), 3.0)
+        filename = os.path.join(self.data_dir, 'tmp_buffered_pad_last.edf')
+
+        f = pyedflib.EdfWriter(filename, 1, buffered=True, pad_with='last')
+        f.setSignalHeader(0, self._buffered_ch_info(fs))
+        for s in range(0, len(x), 30):
+            f.writeSamples([x[s:s + 30]])
+        f.close()
+
+        f = pyedflib.EdfReader(filename)
+        duration = f.file_duration
+        back = f.readSignal(0)
+        f.close()
+
+        self.assertEqual(duration, 3.0)
+        np.testing.assert_allclose(back, 3.0, atol=1e-3)  # no discontinuity
+
+    def test_buffered_writer_pad_with_number(self):
+        """pad_with accepts a fixed numeric fill value."""
+        fs = 100
+        x = np.ones(int(2.5 * fs))
+        filename = os.path.join(self.data_dir, 'tmp_buffered_pad_number.edf')
+
+        f = pyedflib.EdfWriter(filename, 1, buffered=True, pad_with=-2.5)
+        f.setSignalHeader(0, self._buffered_ch_info(fs))
+        for s in range(0, len(x), 30):
+            f.writeSamples([x[s:s + 30]])
+        f.close()
+
+        f = pyedflib.EdfReader(filename)
+        back = f.readSignal(0)
+        f.close()
+
+        np.testing.assert_allclose(back[:len(x)], x, atol=1e-3)
+        np.testing.assert_allclose(back[len(x):], -2.5, atol=1e-3)
+
+    def test_buffered_writer_pad_with_digital(self):
+        """pad_with is interpreted as a digital value when digital=True."""
+        fs = 100
+        x = np.full(int(2.5 * fs), 100, dtype=np.int32)
+        filename = os.path.join(self.data_dir, 'tmp_buffered_pad_digital.edf')
+
+        f = pyedflib.EdfWriter(filename, 1, buffered=True, pad_with=7)
+        f.setSignalHeader(0, self._buffered_ch_info(fs))
+        for s in range(0, len(x), 30):
+            f.writeSamples([x[s:s + 30]], digital=True)
+        f.close()
+
+        f = pyedflib.EdfReader(filename)
+        back = f.readSignal(0, digital=True)
+        f.close()
+
+        np.testing.assert_array_equal(back[:len(x)], x)
+        np.testing.assert_array_equal(back[len(x):], 7)
+
+    def test_buffered_writer_pad_with_invalid(self):
+        filename = os.path.join(self.data_dir, 'tmp_buffered_pad_invalid.edf')
+        with self.assertRaises(ValueError):
+            pyedflib.EdfWriter(filename, 1, buffered=True, pad_with='bogus')
+
 
 if __name__ == '__main__':
     # run_module_suite(argv=sys.argv)


### PR DESCRIPTION
Follow-up to #286, as discussed there.

`EdfWriter(..., pad_with=...)` controls the value used to fill up an incomplete last data record: a number (default `0`, unchanged behaviour) or `'last'` to repeat each signal's last sample. Zero-padding drags the final partial record to the zero line, which shows up as a step discontinuity / spectral edge artifact at the end of biopotential recordings; `'last'` avoids that.

```python
w = pyedflib.EdfWriter('out.edf', 1, buffered=True, pad_with='last')
```

The default stays `0` for backward compatibility — `'last'` is opt-in.

Details worth reviewing:
- `pad_with` applies to both the buffered flush on `close()` and the regular `writeSamples()` tail block, so it behaves the same either way.
- With `pad_with='last'`, the last sample of each channel is tracked separately rather than read from the leftover buffer. With differing sample frequencies a channel can end exactly on a record boundary while another still has leftovers, and reading from the (then empty) buffer would pad a whole record with zeros.
- `digital=True` requires an integer `pad_with` (raises `TypeError`) instead of silently truncating e.g. `2.7` to `2`. A pad value outside the channel range warns that edflib will clip it.
- numpy scalars (`pad_with=signal[-1]`) are accepted; `bool` is rejected.
- Validation happens before the file is opened, so a rejected argument no longer leaves an empty file behind. `close()` now tolerates a partially constructed object, which also fixes a pre-existing `AttributeError` in `__del__` when `__init__` raised (e.g. on the `open_file_writeonly` error path).

6 new tests, one per case above. Full suite passes (82).

🤖 Generated with [Claude Code](https://claude.com/claude-code)