### PR TITLE
Warn when writeSamples() continues after a padded partial record

### DIFF
--- a/pyedflib/edfwriter.py
+++ b/pyedflib/edfwriter.py
@@ -379,6 +379,10 @@ class EdfWriter:
         self._n_records_written = 0
         self._channel_write_pos = 0
         self._n_annotations_written = 0
+        # whether the previous writeSamples() call left a padded, incomplete
+        # data record behind (see the warning in writeSamples, issue #284)
+        self._wrote_partial_record = False
+        self._warned_partial_record = False
 
     def update_header(self) -> None:
         """
@@ -1012,6 +1016,19 @@ class EdfWriter:
             if len(data_list[i]) > 0:
                 self._last_sample[i] = data_list[i][-1]
 
+        # one incomplete record is fine, it is simply padded at the end of the
+        # recording. Writing further samples after one, however, means that the
+        # padding ends up in the middle of the signal (see issue #284)
+        if self._wrote_partial_record and not self._warned_partial_record:
+            self._warned_partial_record = True
+            warnings.warn('The previous writeSamples() call did not fill a '
+                          'complete data record and was padded to the full '
+                          'record length. Writing more samples now places that '
+                          'padding in the middle of the signal and inflates the '
+                          'file duration. Create the EdfWriter with '
+                          'buffered=True to buffer incomplete records across '
+                          'calls instead.')
+
         if self.buffered:
             if self._buffered_digital is None:
                 self._buffered_digital = digital
@@ -1069,10 +1086,14 @@ class EdfWriter:
                                   for i in range(len(data_list))]
             return
 
+        wrote_partial_record = False
         for i in np.arange(len(data_list)):
             lastSampleInd = int(np.max(data_list[i].shape) - ind[i])
             lastSampleInd = int(np.min((lastSampleInd, smp_per_record[i])))
             if lastSampleInd > 0:
+                # a full record needs no padding, fewer samples than that do
+                if lastSampleInd < smp_per_record[i]:
+                    wrote_partial_record = True
                 if self.pad_with == 'last':
                     pad_value = self._last_sample[i]
                 else:
@@ -1092,6 +1113,8 @@ class EdfWriter:
 
                 if success<0:
                     raise OSError(f'Unknown error while calling writeSamples: {success}')
+
+        self._wrote_partial_record = wrote_partial_record
 
     def writeAnnotation(self, onset_in_seconds: Union[int, float],
                         duration_in_seconds: Union[int, float],

--- a/pyedflib/tests/test_edfwriter.py
+++ b/pyedflib/tests/test_edfwriter.py
@@ -1262,8 +1262,10 @@ class TestEdfWriter(unittest.TestCase):
 
         f = pyedflib.EdfWriter(filename, 1)
         f.setSignalHeader(0, self._buffered_ch_info(fs))
-        for s in range(0, len(x), 100):
-            f.writeSamples([np.ascontiguousarray(x[s:s + 100])])
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')  # warns about the padding, see below
+            for s in range(0, len(x), 100):
+                f.writeSamples([np.ascontiguousarray(x[s:s + 100])])
         f.close()
 
         f = pyedflib.EdfReader(filename)
@@ -1488,6 +1490,43 @@ class TestEdfWriter(unittest.TestCase):
         f.writeSamples([np.full(150, 1.0)])
         with self.assertWarns(UserWarning):
             f.close()
+
+    def _count_partial_record_warnings(self, chunks, buffered=False, fs=100):
+        filename = os.path.join(self.data_dir, 'tmp_partial_warn.edf')
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            f = pyedflib.EdfWriter(filename, 1, buffered=buffered)
+            f.setSignalHeader(0, self._buffered_ch_info(fs))
+            for c in chunks:
+                f.writeSamples([np.ascontiguousarray(c)])
+            f.close()
+        return len([w for w in caught
+                    if 'complete data record' in str(w.message)])
+
+    def test_partial_record_warning_on_repeated_subrecord_writes(self):
+        """Writing again after a padded record puts padding mid-signal (#284)."""
+        x = np.zeros(1000)
+        self.assertEqual(
+            self._count_partial_record_warnings([x[:250], x[250:500]]), 1)
+        # a streaming loop must not warn once per call
+        self.assertEqual(
+            self._count_partial_record_warnings(
+                [x[i:i + 30] for i in range(0, 1000, 30)]), 1)
+
+    def test_no_partial_record_warning_when_harmless(self):
+        """A single trailing partial record is normal and must stay silent."""
+        x = np.zeros(1000)
+        # one call, incomplete last record -> padded once at the end
+        self.assertEqual(self._count_partial_record_warnings([x[:250]]), 0)
+        self.assertEqual(self._count_partial_record_warnings([x]), 0)
+        # every call fills whole records, so nothing is ever padded
+        self.assertEqual(
+            self._count_partial_record_warnings(
+                [x[i:i + 100] for i in range(0, 1000, 100)]), 0)
+        # buffering is exactly the recommended fix, so it must not warn
+        self.assertEqual(
+            self._count_partial_record_warnings(
+                [x[i:i + 30] for i in range(0, 1000, 30)], buffered=True), 0)
 
     def test_close_on_partially_constructed_writer(self):
         """__del__ must not raise if __init__ failed before opening the file."""


### PR DESCRIPTION
Stacked on #300 (touches the same tail block) — please merge that first, the base will retarget to master automatically.

Calling `writeSamples()` with less than a full data record pads that record out to the full record length. That is harmless for the last call before `close()` — the format requires complete records — but if more samples follow, the padding lands in the *middle* of the signal and inflates the file duration. That is the failure mode from #284, where a streaming loop feeding 100-sample blocks into a 1000-sample record produced a 10x too long file, silently.

This warns once in exactly that situation and points at `buffered=True`.

The trigger is deliberately the *second* write, not the first: a single incomplete record is normal usage (`highlevel.write_edf` does it on every call), so warning there would fire on almost every correct write. Only once a further call arrives is the earlier padding known to be misplaced. It also warns once rather than per call, so a streaming loop does not emit hundreds of warnings.

Stays silent for:
- a single call with an incomplete trailing record
- a single call with the whole signal
- calls that each fill whole records
- `buffered=True`, which is the recommended fix

The only place it fires in the existing suite is `test_naive_subrecord_blocks_inflate_file`, which documents the #284 behaviour on purpose; that test now suppresses it explicitly.

2 new tests covering both the firing and the silent cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code), reviewed by @skjerns 