### PR TITLE
docs: add Read the Docs v2 build config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,19 @@
+# Read the Docs configuration file.
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details.
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+
+sphinx:
+  configuration: doc/source/conf.py
+
+python:
+  install:
+    # Documentation build dependencies (sphinx, numpydoc, ...).
+    - requirements: requirements-doc.txt
+    # Install pyedflib itself so autodoc can import the compiled extension.
+    - method: pip
+      path: .

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,4 +1,5 @@
 cython
 numpy
 pytest
+sphinx
 numpydoc


### PR DESCRIPTION
Adds an explicit Read the Docs configuration so doc builds are pinned and reproducible. This is the build-safety fix only — it does not update any doc **content** (stale version requirements, copyright, and release notes are follow-ups).

## Why
- The repo has **no `.readthedocs.yaml`**. Config-less builds are deprecated on RTD, and modern RTD no longer auto-installs Sphinx — so builds are at risk.
- `doc/source/conf.py` does `import pyedflib` (a compiled Cython extension), so the build must install the package itself, not just doc deps.

## Changes
- **New `.readthedocs.yaml`** (v2): Ubuntu 24.04 + Python 3.12, builds from `doc/source/conf.py`, installs `requirements-doc.txt` and pyedflib via `pip install .`.
- **`requirements-doc.txt`**: add `sphinx` (RTD no longer provides it by default).

## Compatibility
The package is installed with `method: pip` / `path: .`, which is build-backend agnostic — it works with both the current `setup.py` and the PEP 517 migration in #298. Nothing here references `setup.py`.

## Verification
Ran the exact RTD steps locally (`pip install .` + `sphinx-build -b html doc/source`) → **build succeeded** (9 pre-existing, unrelated warnings).

## Notes / follow-ups
- To also cover RTD's `stable`/tagged version, this file needs to be present in a tagged release, not just `master`.
- Content refresh (version reqs, copyright, `pip` install instructions, release notes 0.1.24–0.1.42) will follow in separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)