### PR TITLE
docs: refresh content and add release notes 0.1.32-0.1.42

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,14 +47,16 @@ Documentation is available online at https://pyedflib.readthedocs.io.
 Installation
 ------------
 
-pyEDFlib can be used with `Python`_ >=3.7. It depends on the `Numpy`_ package.
-To use the newest source code from git, you have to download the source code.
-You need a C compiler and a recent version of `Cython`_. Go then to the source directory and type::
+pyEDFlib can be used with `Python`_ >=3.8. It depends on the `Numpy`_ package.
+To use the newest source code from git, download the source code and, from the
+source directory, install it with::
 
-    python setup.py build
-    python setup.py install
+    pip install .
 
-There are binary wheels which can be installed by (use pip3 when available)::
+This requires a C compiler and a recent version of `Cython`_, which ``pip``
+installs automatically as build dependencies.
+
+There are binary wheels which can be installed by::
 
     pip install pyEDFlib
 

--- a/doc/release/0.1.11-notes.rst
+++ b/doc/release/0.1.11-notes.rst
@@ -3,6 +3,7 @@ PyEDFlib 0.1.11 Release Notes
 ==============================
 
 .. contents::
+
 - Bug fixes
 
 Authors

--- a/doc/release/0.1.32-notes.rst
+++ b/doc/release/0.1.32-notes.rst
@@ -1,0 +1,18 @@
+=============================
+PyEDFlib 0.1.32 Release Notes
+=============================
+
+.. contents::
+
+- Fix the wheel-building GitHub Actions workflow
+
+Authors
+=======
+* Holger Nahrstaedt
+
+Issues closed for v0.1.32
+-------------------------
+
+Pull requests for v0.1.32
+-------------------------
+

--- a/doc/release/0.1.33-notes.rst
+++ b/doc/release/0.1.33-notes.rst
@@ -1,0 +1,33 @@
+=============================
+PyEDFlib 0.1.33 Release Notes
+=============================
+
+.. contents::
+
+- Drop remaining Python 2 leftovers and require Python >= 3.7
+- Add Python 3.11 to the test matrix
+- Modernize the codebase (f-strings, simple super() calls)
+
+Authors
+=======
+* Dimitri Papadopoulos Orfanos
+* Simon Kern
+* Alistair Johnson
+* hofaflo
+
+Issues closed for v0.1.33
+-------------------------
+
+Pull requests for v0.1.33
+-------------------------
+
+* `#200 <https://github.com/holgern/pyedflib/pull/200>`__
+* `#203 <https://github.com/holgern/pyedflib/pull/203>`__
+* `#204 <https://github.com/holgern/pyedflib/pull/204>`__
+* `#205 <https://github.com/holgern/pyedflib/pull/205>`__
+* `#206 <https://github.com/holgern/pyedflib/pull/206>`__
+* `#208 <https://github.com/holgern/pyedflib/pull/208>`__
+* `#210 <https://github.com/holgern/pyedflib/pull/210>`__
+* `#211 <https://github.com/holgern/pyedflib/pull/211>`__
+* `#213 <https://github.com/holgern/pyedflib/pull/213>`__
+* `#216 <https://github.com/holgern/pyedflib/pull/216>`__

--- a/doc/release/0.1.34-notes.rst
+++ b/doc/release/0.1.34-notes.rst
@@ -1,0 +1,34 @@
+=============================
+PyEDFlib 0.1.34 Release Notes
+=============================
+
+.. contents::
+
+- Pin Cython < 3 as a hotfix so the extension keeps building
+- Add tests for the deprecated setGender() API and clarify binary sex assignment
+- Documentation and CI housekeeping (bitbucket -> github, sphinx links)
+
+Authors
+=======
+* Simon Kern
+* Dimitri Papadopoulos Orfanos
+* WEN Hao
+* emmanuel-ferdman
+
+Issues closed for v0.1.34
+-------------------------
+
+Pull requests for v0.1.34
+-------------------------
+
+* `#212 <https://github.com/holgern/pyedflib/pull/212>`__
+* `#214 <https://github.com/holgern/pyedflib/pull/214>`__
+* `#217 <https://github.com/holgern/pyedflib/pull/217>`__
+* `#220 <https://github.com/holgern/pyedflib/pull/220>`__
+* `#221 <https://github.com/holgern/pyedflib/pull/221>`__
+* `#222 <https://github.com/holgern/pyedflib/pull/222>`__
+* `#223 <https://github.com/holgern/pyedflib/pull/223>`__
+* `#224 <https://github.com/holgern/pyedflib/pull/224>`__
+* `#227 <https://github.com/holgern/pyedflib/pull/227>`__
+* `#229 <https://github.com/holgern/pyedflib/pull/229>`__
+* `#234 <https://github.com/holgern/pyedflib/pull/234>`__

--- a/doc/release/0.1.35-notes.rst
+++ b/doc/release/0.1.35-notes.rst
@@ -1,0 +1,25 @@
+=============================
+PyEDFlib 0.1.35 Release Notes
+=============================
+
+.. contents::
+
+- Add support for Python 3.12
+- Add a highlevel ``crop_edf`` function
+- Add rounding when converting seconds to samples
+
+Authors
+=======
+* Raphael Vallat
+* Simon Kern
+* Clemens Brunner
+
+Issues closed for v0.1.35
+-------------------------
+
+Pull requests for v0.1.35
+-------------------------
+
+* `#196 <https://github.com/holgern/pyedflib/pull/196>`__
+* `#239 <https://github.com/holgern/pyedflib/pull/239>`__
+* `#240 <https://github.com/holgern/pyedflib/pull/240>`__

--- a/doc/release/0.1.36-notes.rst
+++ b/doc/release/0.1.36-notes.rst
@@ -1,0 +1,20 @@
+=============================
+PyEDFlib 0.1.36 Release Notes
+=============================
+
+.. contents::
+
+- Build x86_64 and arm64 macOS wheels
+- Drop the x86 wheel build for Python 3.12
+
+Authors
+=======
+* Simon Kern
+
+Issues closed for v0.1.36
+-------------------------
+
+Pull requests for v0.1.36
+-------------------------
+
+* `#245 <https://github.com/holgern/pyedflib/pull/245>`__

--- a/doc/release/0.1.37-notes.rst
+++ b/doc/release/0.1.37-notes.rst
@@ -1,0 +1,28 @@
+=============================
+PyEDFlib 0.1.37 Release Notes
+=============================
+
+.. contents::
+
+- Add support for Cython 3 (fix relative cimport, revert the Cython < 3 pin)
+- Support opening UTF-8 encoded paths on Windows
+- Support writing UTF-8 in write-only mode
+
+Authors
+=======
+* Simon Kern
+* Benjamin A. Beasley
+* Dimitri Papadopoulos Orfanos
+* myd7349
+
+Issues closed for v0.1.37
+-------------------------
+
+Pull requests for v0.1.37
+-------------------------
+
+* `#209 <https://github.com/holgern/pyedflib/pull/209>`__
+* `#237 <https://github.com/holgern/pyedflib/pull/237>`__
+* `#246 <https://github.com/holgern/pyedflib/pull/246>`__
+* `#248 <https://github.com/holgern/pyedflib/pull/248>`__
+* `#252 <https://github.com/holgern/pyedflib/pull/252>`__

--- a/doc/release/0.1.38-notes.rst
+++ b/doc/release/0.1.38-notes.rst
@@ -1,0 +1,19 @@
+=============================
+PyEDFlib 0.1.38 Release Notes
+=============================
+
+.. contents::
+
+- Add support for NumPy 2
+
+Authors
+=======
+* Simon Kern
+
+Issues closed for v0.1.38
+-------------------------
+
+Pull requests for v0.1.38
+-------------------------
+
+* `#260 <https://github.com/holgern/pyedflib/pull/260>`__

--- a/doc/release/0.1.39-notes.rst
+++ b/doc/release/0.1.39-notes.rst
@@ -1,0 +1,27 @@
+=============================
+PyEDFlib 0.1.39 Release Notes
+=============================
+
+.. contents::
+
+- Add type hints to the main APIs
+- Deprecate ``sample_rate`` in favor of ``sample_frequency``
+- Convert the ``phys_min``/``phys_max`` assertions into warnings
+- Add more test cases for ``record_duration``
+
+Authors
+=======
+* Simon Kern
+* Joseph
+* Wouter Potters
+
+Issues closed for v0.1.39
+-------------------------
+
+Pull requests for v0.1.39
+-------------------------
+
+* `#264 <https://github.com/holgern/pyedflib/pull/264>`__
+* `#266 <https://github.com/holgern/pyedflib/pull/266>`__
+* `#268 <https://github.com/holgern/pyedflib/pull/268>`__
+* `#272 <https://github.com/holgern/pyedflib/pull/272>`__

--- a/doc/release/0.1.41-notes.rst
+++ b/doc/release/0.1.41-notes.rst
@@ -1,0 +1,25 @@
+=============================
+PyEDFlib 0.1.41 Release Notes
+=============================
+
+.. contents::
+
+- Fix writing of UTF-8 characters
+- Fix reading of UTF-8 annotations
+- Remove Python 2.7 leftovers and start applying ruff rules
+
+Authors
+=======
+* Simon Kern
+* Dimitri Papadopoulos Orfanos
+
+Issues closed for v0.1.41
+-------------------------
+
+Pull requests for v0.1.41
+-------------------------
+
+* `#269 <https://github.com/holgern/pyedflib/pull/269>`__
+* `#270 <https://github.com/holgern/pyedflib/pull/270>`__
+* `#276 <https://github.com/holgern/pyedflib/pull/276>`__
+* `#277 <https://github.com/holgern/pyedflib/pull/277>`__

--- a/doc/release/0.1.42-notes.rst
+++ b/doc/release/0.1.42-notes.rst
@@ -1,0 +1,18 @@
+=============================
+PyEDFlib 0.1.42 Release Notes
+=============================
+
+.. contents::
+
+- Fix wheel building and clean up the PyPI package metadata
+
+Authors
+=======
+* Simon Kern
+
+Issues closed for v0.1.42
+-------------------------
+
+Pull requests for v0.1.42
+-------------------------
+

--- a/doc/release/0.1.8-notes.rst
+++ b/doc/release/0.1.8-notes.rst
@@ -3,6 +3,7 @@ PyEDFlib 0.1.8 Release Notes
 ============================
 
 .. contents::
+
 - Fix proper reading of EDF/BDF files
 - Fix writing of EDF/BDF files
 

--- a/doc/release/0.1.9-notes.rst
+++ b/doc/release/0.1.9-notes.rst
@@ -3,6 +3,7 @@ PyEDFlib 0.1.9 Release Notes
 ============================
 
 .. contents::
+
 - Fix proper reading of EDF/BDF files
 - Bug fixes
 - Improved error messages

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'pyEDFlib'
-copyright = '2015 - 2022, Holger Nahrstaedt'
+copyright = '2015 - 2026, Holger Nahrstaedt'
 author = 'Holger Nahrstaedt'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/doc/source/dev/how_to_release.rst
+++ b/doc/source/dev/how_to_release.rst
@@ -1,49 +1,42 @@
-Guidelines for new releases for pyedflib
+Guidelines for new releases for pyEDFlib
 ========================================
-vX.X.X refers to the release number
 
-Tag the release and trigger building of wheels in appvoyer
-----------------------------------------------------------
-Change ISRELEASED in setup.py to True and commit.
+``vX.Y.Z`` refers to the release number.
 
-Appveyor will now build wheels for windows.
+Releases are built and published automatically by the ``Build wheel`` GitHub
+Actions workflow (``.github/workflows/wheels.yml``). It runs on every pushed
+tag matching ``vX.Y.Z``, builds the source distribution and the platform
+wheels (Linux, macOS and Windows, CPython 3.8-3.14, including aarch64) and
+uploads them to PyPI using the ``PYPI_API_TOKEN`` repository secret.
 
-Tag the release with
+Bump the version
+----------------
 
-```git tag -s vX.X.X```
+Set the version in ``setup.py`` by editing ``MAJOR``, ``MINOR`` and ``MICRO``,
+and set ``ISRELEASED = True``. Commit the change.
 
-and push the tag to master.
+Add release notes
+-----------------
 
-Clean up source
----------------
-Remove untraced files with git clean
+Add a ``doc/release/X.Y.Z-notes.rst`` file describing the changes, together
+with a matching ``doc/source/release.X.Y.Z.rst`` stub that includes it, and
+link the new entry from ``doc/source/releasenotes.rst``.
 
-First check which files will be deleted:
+Tag and push
+------------
 
-```git clean -xfdn```
+Create a signed tag and push it to GitHub::
 
-Then run without -n:
+    git tag -s vX.Y.Z -m "pyEDFlib X.Y.Z"
+    git push origin vX.Y.Z
 
-```git clean -xfd```
-
-Create the source distribution files with:
-
-```python setup.py sdist --formats=gztar,zip```
-
-Upload the release and windows wheels to pypi
----------------------------------------------
-
-Download all wheels from Appveyor and put them into the dist directory
-
-Register all files with
-
-```twine register dist\filename_which_should_uploaded.whl```
-
-and upload with
-
-```twine upload dist\filename_which_should_uploaded.whl```
+Pushing the tag triggers the ``Build wheel`` workflow, which builds the sdist
+and wheels and publishes them to PyPI automatically. Follow the run on the
+GitHub Actions tab and verify the new release appears on
+https://pypi.org/project/pyEDFlib/.
 
 Prepare for continued development
 ---------------------------------
 
-Increment the version number in setup.py and change ISRELEASED to False.
+Increment ``MICRO`` in ``setup.py`` and set ``ISRELEASED = False`` again, then
+commit.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -39,7 +39,7 @@ Requirements
 
 ``PyEDFlib`` requires:
 
-- Python_ >=3.7
+- Python_ >=3.8
 - Numpy_ >= 1.9.1
 
 Download

--- a/doc/source/release.0.1.32.rst
+++ b/doc/source/release.0.1.32.rst
@@ -1,0 +1,1 @@
+.. include:: ../release/0.1.32-notes.rst

--- a/doc/source/release.0.1.33.rst
+++ b/doc/source/release.0.1.33.rst
@@ -1,0 +1,1 @@
+.. include:: ../release/0.1.33-notes.rst

--- a/doc/source/release.0.1.34.rst
+++ b/doc/source/release.0.1.34.rst
@@ -1,0 +1,1 @@
+.. include:: ../release/0.1.34-notes.rst

--- a/doc/source/release.0.1.35.rst
+++ b/doc/source/release.0.1.35.rst
@@ -1,0 +1,1 @@
+.. include:: ../release/0.1.35-notes.rst

--- a/doc/source/release.0.1.36.rst
+++ b/doc/source/release.0.1.36.rst
@@ -1,0 +1,1 @@
+.. include:: ../release/0.1.36-notes.rst

--- a/doc/source/release.0.1.37.rst
+++ b/doc/source/release.0.1.37.rst
@@ -1,0 +1,1 @@
+.. include:: ../release/0.1.37-notes.rst

--- a/doc/source/release.0.1.38.rst
+++ b/doc/source/release.0.1.38.rst
@@ -1,0 +1,1 @@
+.. include:: ../release/0.1.38-notes.rst

--- a/doc/source/release.0.1.39.rst
+++ b/doc/source/release.0.1.39.rst
@@ -1,0 +1,1 @@
+.. include:: ../release/0.1.39-notes.rst

--- a/doc/source/release.0.1.41.rst
+++ b/doc/source/release.0.1.41.rst
@@ -1,0 +1,1 @@
+.. include:: ../release/0.1.41-notes.rst

--- a/doc/source/release.0.1.42.rst
+++ b/doc/source/release.0.1.42.rst
@@ -1,0 +1,1 @@
+.. include:: ../release/0.1.42-notes.rst

--- a/doc/source/releasenotes.rst
+++ b/doc/source/releasenotes.rst
@@ -20,3 +20,19 @@ Release Notes
    release.0.1.21
    release.0.1.22
    release.0.1.23
+   release.0.1.24
+   release.0.1.25
+   release.0.1.26
+   release.0.1.27
+   release.0.1.28
+   release.0.1.31
+   release.0.1.32
+   release.0.1.33
+   release.0.1.34
+   release.0.1.35
+   release.0.1.36
+   release.0.1.37
+   release.0.1.38
+   release.0.1.39
+   release.0.1.41
+   release.0.1.42


### PR DESCRIPTION
Follow-up to #308 (build config). This updates the doc **content** that had drifted from the code. Two logical commits.

## B — Refresh stale facts
- **Minimum Python 3.7 → 3.8** in `index.rst` and `README.rst` (matches the CI matrix `3.8`–`3.14` and ruff `target-version = py38`).
- **`README.rst`**: replace deprecated `python setup.py build/install` with `pip install .`.
- **`conf.py`**: copyright year → 2026.
- **`dev/how_to_release.rst`**: rewritten for the current GitHub Actions flow (tag push → `wheels.yml` builds sdist + wheels and auto-publishes to PyPI) instead of the removed AppVeyor / manual `twine` process.

## C — Release notes catch-up
The release-notes toctree stopped at **0.1.23**; notes for 0.1.24–0.1.31 existed but were never linked, and nothing existed for 0.1.32–0.1.42.
- **Add notes for 0.1.32 → 0.1.42** (summary, authors, merged PRs), generated from the git history between tags.
- **Relink the orphaned 0.1.24–0.1.31** notes into `releasenotes.rst`.
- Fix a pre-existing markup warning in the 0.1.8/0.1.9/0.1.11 notes.

## Verification
Built locally with the RTD toolchain (`sphinx-build -b html doc/source`) → **build succeeded, 0 warnings** (down from the 3 pre-existing warnings on master).

## Known remaining gaps (out of scope here)
- Tags **0.1.13, 0.1.14, 0.1.29, 0.1.30** were released but never had notes; **0.1.40** was skipped entirely. Left as-is to keep this PR focused on the 0.1.32–0.1.42 catch-up.
- Author names were consolidated by hand (`skjerns` → Simon Kern, two Dimitri spellings merged); a `.mailmap` would make this automatic in future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)