### PR TITLE
Fix reading and writing subsecond part of start time

### DIFF
--- a/pyedflib/edfreader.py
+++ b/pyedflib/edfreader.py
@@ -434,8 +434,8 @@ class EdfReader(CyEdfReader):
         >>> f.close()
 
         """
-        # denoted as long long in nanoseconds, we need to transfer it to microsecond
-        subsecond = np.round(self.starttime_subsecond / 100).astype(int)
+        # denoted as long long in units of 100 nanoseconds, we need to convert it to microseconds
+        subsecond = np.round(self.starttime_subsecond / 10).astype(int)
         return datetime(
             self.startdate_year,
             self.startdate_month,

--- a/pyedflib/edfwriter.py
+++ b/pyedflib/edfwriter.py
@@ -434,9 +434,9 @@ class EdfWriter:
         set_startdatetime(self.handle, self.recording_start_time.year, self.recording_start_time.month,
                           self.recording_start_time.day, self.recording_start_time.hour,
                           self.recording_start_time.minute, self.recording_start_time.second)
-        # subseconds are noted in nanoseconds, so we multiply by 100
+        # subseconds are noted in units of 100 nanoseconds, so we multiply by 10
         if self.recording_start_time.microsecond>0:
-            set_starttime_subsecond(self.handle, self.recording_start_time.microsecond*100)
+            set_starttime_subsecond(self.handle, self.recording_start_time.microsecond*10)
         if isinstance(self.birthdate, str):
             if self.birthdate != '':
                 birthday = datetime.strptime(self.birthdate, '%d %b %Y').date()

--- a/pyedflib/tests/test_edfreader.py
+++ b/pyedflib/tests/test_edfreader.py
@@ -227,7 +227,7 @@ class TestEdfReader(unittest.TestCase):
 
     def test_EdfReader_subsecond(self):
         f = pyedflib.EdfReader(self.edf_subsecond)
-        self.assertEqual(f.getStartdatetime(), datetime(2020, 1, 24, 4, 5, 56, 39453))
+        self.assertEqual(f.getStartdatetime(), datetime(2020, 1, 24, 4, 5, 56, 394531))
 
 
     def test_EdfReader_ReadAnnotations(self):


### PR DESCRIPTION
Fixes the incorrectly read and written subsecond part in start timeand corrects the test case.

As noted in the [EDFlib documentation](https://www.teuniz.net/edflib/doc/edflib_8h.html#a5dc9e8730281c4937745902b70d86dd7), the subsecond start time is expressed in units of 100 nanoseconds, so the conversion factor to microseconds expected by _datetime_ should be 10 not 100.
Also the corresponding pytest checked against _2020-01-24 04:05:56.039453_ instead of the correct _2020-01-24 04:05:56.394531_.