### PR TITLE
Fix change_polarity(): crash on every call and incorrect inversion

### DIFF
--- a/pyedflib/highlevel.py
+++ b/pyedflib/highlevel.py
@@ -1018,6 +1018,39 @@ def rename_channels(
     return write_edf(new_file, signals, signal_headers, header, digital=True)
 
 
+def _verify_polarity(
+    edf_source: str,
+    edf_target: str,
+    inverted: Iterable[int],
+    verbose: bool = False,
+) -> None:
+    """
+    Check that `edf_target` holds the physical values of `edf_source` with
+    the polarity of the channels in `inverted` flipped, and all other
+    channels unchanged.
+
+    Raises an AssertionError if that is not the case.
+
+    Note that compare_edf() cannot be used for this: it compares absolute
+    values, so it passes whether or not a channel was actually inverted.
+    """
+    orig, orig_sheads, _ = read_edf(edf_source, verbose=verbose)
+    new, _, _ = read_edf(edf_target, verbose=verbose)
+    inverted = set(inverted)
+    for i, (s_old, s_new) in enumerate(zip(orig, new)):
+        expected = -s_old if i in inverted else s_old
+        shead = orig_sheads[i]
+        # the physical values are stored in steps of one digital unit, so
+        # half a step is a generous tolerance that still catches an error
+        # of a whole unit
+        step = abs((shead['physical_max'] - shead['physical_min'])
+                   / (shead['digital_max'] - shead['digital_min']))
+        if not np.allclose(s_new, expected, atol=step / 2, rtol=0):
+            raise AssertionError(
+                f'polarity of channel {i} ({shead["label"]}) was not '
+                f'correctly inverted in {edf_target}')
+
+
 def change_polarity(
     edf_file: str,
     channels: List[Union[str, int]],
@@ -1032,12 +1065,15 @@ def change_polarity(
     ----------
     edf_file : str
         from which file to change polarity.
-    channels : list of int
-        the indices of the channels.
+    channels : list of int or list of str
+        the indices or the labels of the channels to invert. Negative
+        indices count from the end. Labels are matched case-insensitively.
     new_file : str, optional
-        where to save the edf with inverted channels. The default is None.
+        where to save the edf with inverted channels. If None, the input
+        filename appended with '_inverted' is used. The default is None.
     verify : bool, optional
-        whether to verify the two edfs for similarity. The default is True.
+        whether to check that the new file holds the negated physical
+        values of the selected channels. The default is True.
     verbose : str, optional
         print progress or not. The default is True.
 
@@ -1049,22 +1085,49 @@ def change_polarity(
     """
 
     if new_file is None:
-        new_file = f"{os.path.splitext(edf_file)[0]}.edf"
+        file, ext = os.path.splitext(edf_file)
+        new_file = f"{file}_inverted{ext}"
+    assert edf_file != new_file, 'For safety, target must not be source file.'
 
-    if isinstance(channels, str):
-        channels=[channels]
-    channels = [c.lower() for c in channels]
+    if isinstance(channels, (str, int)):
+        channels = [channels]
 
     signals, signal_headers, header = read_edf(edf_file, digital=True,
                                                verbose=verbose)
-    for i,sig in enumerate(signals):
-        label = signal_headers[i]['label'].lower()
-        if label in channels:
-            if verbose:
-                print(f'inverting {label}')
-            signals[i] = -sig
-    write_edf(new_file, signals, signal_headers, header,
-              digital=True, correct=False, verbose=verbose)
+
+    # channels can be given either as labels or as indices
+    labels = [shead['label'].lower() for shead in signal_headers]
+    to_invert = set()
+    for ch in channels:
+        if isinstance(ch, str):
+            if ch.lower() not in labels:
+                raise ValueError(f'channel {ch} is not in {edf_file} '
+                                 f'(contains {labels})')
+            to_invert.add(labels.index(ch.lower()))
+        else:
+            idx = len(labels) + ch if ch < 0 else ch
+            if not 0 <= idx < len(labels):
+                raise IndexError(f'channel index {ch} is out of range, '
+                                 f'{edf_file} has {len(labels)} channels')
+            to_invert.add(idx)
+
+    for i in sorted(to_invert):
+        if verbose:
+            print(f'inverting {signal_headers[i]["label"]}')
+        shead = signal_headers[i]
+        dmin, dmax = int(shead['digital_min']), int(shead['digital_max'])
+        # Inverting the polarity means negating the *physical* values.
+        # Reflecting the digital samples within [dmin, dmax] and negating the
+        # physical range does exactly that, with integer arithmetic and
+        # without rounding, clipping or a change of the digital range.
+        # Negating the digital samples alone (as this function used to do) is
+        # off by dmin+dmax digital units, and cannot represent the result at
+        # all for a physical range that does not straddle zero, e.g. 0...100.
+        signals[i] = dmin + dmax - signals[i]
+        shead['physical_min'], shead['physical_max'] = \
+            -shead['physical_max'], -shead['physical_min']
+
+    write_edf(new_file, signals, signal_headers, header, digital=True)
     if verify:
-        compare_edf(edf_file, new_file)
+        _verify_polarity(edf_file, new_file, to_invert, verbose=verbose)
     return True

--- a/pyedflib/tests/test_highlevel.py
+++ b/pyedflib/tests/test_highlevel.py
@@ -447,6 +447,82 @@ class TestHighLevel(unittest.TestCase):
         _,_,header3 = highlevel.read_edf(self.edfplus_data_file)
         self.assertEqual(header2['annotations'], header3['annotations'])
 
+    def test_change_polarity(self):
+        data_dir = os.path.join(os.path.dirname(__file__), 'data')
+        edf_file = os.path.join(data_dir, 'tmp_polarity.edf')
+        outfile = os.path.join(data_dir, 'tmp_polarity_out.edf')
+
+        signal_headers = highlevel.make_signal_headers(
+            ['ch0', 'ch1', 'ch2'], sample_frequency=100,
+            physical_min=-200, physical_max=200)
+        signals = np.random.rand(3, 100 * 10) * 100
+        highlevel.write_edf(edf_file, signals, signal_headers)
+        orig, orig_sheads, _ = highlevel.read_edf(edf_file)
+
+        def inverted_channels(file):
+            """indices whose physical values were negated, to within the
+            resolution the values are stored with"""
+            new, _, _ = highlevel.read_edf(file)
+            step = ((orig_sheads[0]['physical_max'] - orig_sheads[0]['physical_min'])
+                    / (orig_sheads[0]['digital_max'] - orig_sheads[0]['digital_min']))
+            return {i for i in range(len(new))
+                    if np.allclose(new[i], -orig[i], atol=step / 2, rtol=0)}
+
+        # select by label (case-insensitive), by index and by negative index
+        for channels, expected in [(['ch1'], {1}), (['CH1'], {1}), ([1], {1}),
+                                   ([-2], {1}), (['ch0', 2], {0, 2}),
+                                   ('ch1', {1}), (1, {1})]:
+            assert highlevel.change_polarity(edf_file, channels,
+                                             new_file=outfile)
+            assert inverted_channels(outfile) == expected, channels
+            # the channels that were not selected must be untouched
+            new, _, _ = highlevel.read_edf(outfile, digital=True)
+            orig_dig, _, _ = highlevel.read_edf(edf_file, digital=True)
+            for i in set(range(3)) - expected:
+                np.testing.assert_array_equal(new[i], orig_dig[i])
+
+        # the default target must not overwrite the source file (gh: the old
+        # default resolved to the input path for .edf files)
+        default_file = os.path.join(data_dir, 'tmp_polarity_inverted.edf')
+        highlevel.change_polarity(edf_file, ['ch1'])
+        assert os.path.isfile(default_file)
+        again, _, _ = highlevel.read_edf(edf_file)
+        np.testing.assert_array_equal(again, orig)
+        assert inverted_channels(default_file) == {1}
+
+        # unknown labels and out-of-range indices must not pass silently
+        with self.assertRaises(ValueError):
+            highlevel.change_polarity(edf_file, ['not_a_channel'],
+                                      new_file=outfile)
+        with self.assertRaises(IndexError):
+            highlevel.change_polarity(edf_file, [3], new_file=outfile)
+
+    def test_change_polarity_asymmetric_range(self):
+        # a physical range that does not straddle zero (e.g. SpO2 in %)
+        # cannot be inverted by negating the digital values, the physical
+        # range has to be negated as well
+        data_dir = os.path.join(os.path.dirname(__file__), 'data')
+        edf_file = os.path.join(data_dir, 'tmp_polarity_asym.edf')
+        outfile = os.path.join(data_dir, 'tmp_polarity_asym_out.edf')
+
+        signal_headers = highlevel.make_signal_headers(
+            ['spo2'], dimension='%', sample_frequency=100,
+            physical_min=0, physical_max=100)
+        signals = np.random.rand(1, 100 * 10) * 100
+        highlevel.write_edf(edf_file, signals, signal_headers)
+        orig, orig_sheads, _ = highlevel.read_edf(edf_file)
+
+        # verify=True does the physical round-trip check internally
+        assert highlevel.change_polarity(edf_file, ['spo2'], new_file=outfile,
+                                         verify=True)
+
+        new, new_sheads, _ = highlevel.read_edf(outfile)
+        step = 100 / (orig_sheads[0]['digital_max'] - orig_sheads[0]['digital_min'])
+        np.testing.assert_allclose(new[0], -orig[0], atol=step / 2, rtol=0)
+        # the physical range must have been negated to stay representable
+        self.assertEqual(new_sheads[0]['physical_min'], -100)
+        self.assertEqual(new_sheads[0]['physical_max'], 0)
+
     def test_deprecated_sample_rate(self):
         header = highlevel.make_header(technician='tech', recording_additional='radd',
                                                 patientname='name', patient_additional='padd',


### PR DESCRIPTION
`change_polarity()` has no test coverage and is broken in two ways.

## It raises `TypeError` on every call

It passes `correct=` and `verbose=` to `write_edf()`, neither of which that function accepts (any more):

```
TypeError: write_edf() got an unexpected keyword argument 'correct'
```

## The inversion is wrong

Negating the digital samples is not a polarity inversion. With `phys = m*(dig + b)`, negating `dig` gives `m*(-dig + b)` while inverting gives `m*(-dig - b)` — off by `2b` digital units, exactly 1 LSB for the usual `-32768...32767` range. And for a physical range that does not straddle zero (an SpO2 channel with `0...100`), the negated values are not representable in that header at all, so no choice of digital samples can encode them. Negating could also overflow, since `-(-32768)` exceeds `digital_max`.

This PR reflects the digital samples inside `[dmin, dmax]` and negates the physical range instead:

```python
signals[i] = dmin + dmax - signals[i]
shead['physical_min'], shead['physical_max'] = -shead['physical_max'], -shead['physical_min']
```

Because EDF maps `dmin -> pmin` and `dmax -> pmax`, this reverses the mapping exactly, with integer arithmetic only: no rounding, no clipping, and the reflection maps `[dmin, dmax]` bijectively onto itself so overflow is impossible. `physical_min < physical_max` ordering is preserved. Measured end to end, the error is exactly 0.0 for both a symmetric `-200...200` and an asymmetric `0...100` range.

`verify=True` also had to change: it called `compare_edf()`, which compares **absolute** values and so passed whether or not a channel was actually inverted — it would have accepted the buggy result too. It now checks the signed relationship. `compare_edf()` itself is untouched.

## Also fixed while making the function work

- The default `new_file` resolved to the source path for `.edf` input, overwriting the file it was reading. Now appends `_inverted`, matching the `_dropped`/`_anonymized`/`_renamed`/`_cropped` convention, plus a target-≠-source guard.
- Integer channel indices raised `AttributeError`, though the signature and docstring both document indices as the primary usage. Labels and indices are both accepted now, negative indices included.
- A misspelled channel name matched nothing and returned `True` after writing an unmodified copy. Now raises `ValueError` / `IndexError`.

## Tests

Cover label/index selection, exactness of the inversion for both range types, that unselected channels stay byte-identical, that the default target does not clobber the source, and both error paths. Checked against the old arithmetic as a negative control: restoring `signals[i] = -signals[i]` makes both fail, so they pin the arithmetic and not just the absence of the `TypeError`.

Full suite: 84 passed.

Note: the failing `ruff` check is pre-existing and unrelated — `ruff-action` pins no version and now installs 0.16.1, which ignores the `extend-select` set in `pyproject.toml` and enables 454 rules. #315 fails identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
