### PR TITLE
Warn when writeSamples() continues after a padded partial record

### DIFF
--- a/pyedflib/edfwriter.py
+++ b/pyedflib/edfwriter.py
@@ -446,6 +446,10 @@ class EdfWriter:
         self._n_records_written = 0
         self._channel_write_pos = 0
         self._n_annotations_written = 0
+        # whether the previous writeSamples() call left a padded, incomplete
+        # data record behind (see the warning in writeSamples, issue #284)
+        self._wrote_partial_record = False
+        self._warned_partial_record = False
 
     def update_header(self) -> None:
         """
@@ -1165,6 +1169,19 @@ class EdfWriter:
             if len(channel) > 0:
                 self._last_sample[i] = channel[-1]
 
+        # one incomplete record is fine, it is simply padded at the end of the
+        # recording. Writing further samples after one, however, means that the
+        # padding ends up in the middle of the signal (see issue #284)
+        if self._wrote_partial_record and not self._warned_partial_record:
+            self._warned_partial_record = True
+            warnings.warn(
+                "The previous writeSamples() call did not fill a complete data "
+                "record and was padded to the full record length. Writing more "
+                "samples now places that padding in the middle of the signal and "
+                "inflates the file duration. Create the EdfWriter with "
+                "buffered=True to buffer incomplete records across calls instead."
+            )
+
         if self.buffered:
             if self._buffered_digital is None:
                 self._buffered_digital = digital
@@ -1231,10 +1248,14 @@ class EdfWriter:
             ]
             return
 
+        wrote_partial_record = False
         for i in np.arange(len(data_list)):
             lastSampleInd = int(np.max(data_list[i].shape) - ind[i])
             lastSampleInd = int(np.min((lastSampleInd, smp_per_record[i])))
             if lastSampleInd > 0:
+                # a full record needs no padding, fewer samples than that do
+                if lastSampleInd < smp_per_record[i]:
+                    wrote_partial_record = True
                 pad_value = self._get_pad_value(i, digital)
                 lastSamples = np.full(smp_per_record[i], pad_value, dtype=np.int32 if digital else np.float64)
                 lastSamples[:lastSampleInd] = data_list[i][-lastSampleInd:]
@@ -1245,6 +1266,8 @@ class EdfWriter:
 
                 if success < 0:
                     raise OSError(f"Unknown error while calling writeSamples: {success}")
+
+        self._wrote_partial_record = wrote_partial_record
 
     def writeAnnotation(
         self,

--- a/pyedflib/tests/test_edfwriter.py
+++ b/pyedflib/tests/test_edfwriter.py
@@ -1335,8 +1335,10 @@ class TestEdfWriter(unittest.TestCase):
 
         f = pyedflib.EdfWriter(filename, 1)
         f.setSignalHeader(0, self._buffered_ch_info(fs))
-        for s in range(0, len(x), 100):
-            f.writeSamples([np.ascontiguousarray(x[s : s + 100])])
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")  # warns about the padding, see below
+            for s in range(0, len(x), 100):
+                f.writeSamples([np.ascontiguousarray(x[s : s + 100])])
         f.close()
 
         f = pyedflib.EdfReader(filename)
@@ -1560,6 +1562,40 @@ class TestEdfWriter(unittest.TestCase):
         f.writeSamples([np.full(150, 1.0)])
         with self.assertWarns(UserWarning):
             f.close()
+
+    def _count_partial_record_warnings(self, chunks, buffered=False, fs=100):
+        filename = os.path.join(self.data_dir, "tmp_partial_warn.edf")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            f = pyedflib.EdfWriter(filename, 1, buffered=buffered)
+            f.setSignalHeader(0, self._buffered_ch_info(fs))
+            for c in chunks:
+                f.writeSamples([np.ascontiguousarray(c)])
+            f.close()
+        return len([w for w in caught if "complete data record" in str(w.message)])
+
+    def test_partial_record_warning_on_repeated_subrecord_writes(self):
+        """Writing again after a padded record puts padding mid-signal (#284)."""
+        x = np.zeros(1000)
+        self.assertEqual(self._count_partial_record_warnings([x[:250], x[250:500]]), 1)
+        # a streaming loop must not warn once per call
+        self.assertEqual(self._count_partial_record_warnings([x[i : i + 30] for i in range(0, 1000, 30)]), 1)
+
+    def test_no_partial_record_warning_when_harmless(self):
+        """A single trailing partial record is normal and must stay silent."""
+        x = np.zeros(1000)
+        # one call, incomplete last record -> padded once at the end
+        self.assertEqual(self._count_partial_record_warnings([x[:250]]), 0)
+        self.assertEqual(self._count_partial_record_warnings([x]), 0)
+        # every call fills whole records, so nothing is ever padded
+        self.assertEqual(
+            self._count_partial_record_warnings([x[i : i + 100] for i in range(0, 1000, 100)]), 0
+        )
+        # buffering is exactly the recommended fix, so it must not warn
+        self.assertEqual(
+            self._count_partial_record_warnings([x[i : i + 30] for i in range(0, 1000, 30)], buffered=True),
+            0,
+        )
 
     def test_set_raises_on_rejected_header_field(self):
         """_set() must not let a rejected header field pass silently."""


### PR DESCRIPTION
Applies the change from #301 again. That PR was merged, but the change never arrived in `master`.

Closes #284.

## What went wrong

#301 was a stacked PR. Its base was the branch `pad-with-option`, not `master`.

| time (2026-07-21) | event |
|---|---|
| 17:03 | #300 squash-merges `pad-with-option` into `master` |
| 17:56 | #301 merges into `pad-with-option` — 53 minutes too late |

The base branch was already in `master` when #301 merged into it. `master` uses squash merges, so `pad-with-option` is not an ancestor of `master` and no later merge picked the change up. The branch was also not deleted after #300, so GitHub did not re-target the open #301 to `master` on its own.

No force push caused this. The repository activity log shows zero force pushes since 2026-05-10, and all 27 other PRs merged into `master` in that period are still present.

## The change

If `writeSamples()` gets less than a full data record, that record is padded to the record length. This is correct for the last call before `close()`. If more samples follow, the padding goes into the middle of the signal and makes the file duration too long.

This adds a warning for that case. The warning is given one time only, and points to `buffered=True`. A single trailing partial record, record-aligned calls and buffered writers stay silent, so the usual single-call usage does not change.

`edfwriter.py` is +23/-0, the same as in #301. The test part was applied again by hand, because #304 (`ruff format`) reformatted both files after #301 was written.

## Test

- 89 tests pass
- `ruff check` and `ruff format --check` are clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)