### PR TITLE
Migrate to pyproject.toml with PEP 621 metadata

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -21,10 +21,8 @@ jobs:
         python-version: 3.9
     - name: Generate coverage report
       run: |
-        pip install pytest
-        pip install pytest-cov
         pip install -e . --group test
-        pytest --cov=./pyedflib/ --cov-report=xml --cov-config=.coveragerc
+        python -m pytest --cov=./pyedflib/ --cov-report=xml --cov-config=.coveragerc
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v7
       with:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -23,8 +23,7 @@ jobs:
       run: |
         pip install pytest
         pip install pytest-cov
-        pip install -e .
-        pip install -r requirements-test.txt
+        pip install -e . --group test
         pytest --cov=./pyedflib/ --cov-report=xml --cov-config=.coveragerc
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,5 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install packages
       run: |
-        pip install pytest
         pip install -e . --group test
-        pytest
+        python -m pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,5 @@ jobs:
     - name: Install packages
       run: |
         pip install pytest
-        pip install -e .
-        pip install -r requirements-test.txt
+        pip install -e . --group test
         pytest

--- a/.github/workflows/testz_numpy_2_compatibility.yml
+++ b/.github/workflows/testz_numpy_2_compatibility.yml
@@ -20,6 +20,5 @@ jobs:
       run: |
         pip install numpy==1.24
         pip install pytest
-        pip install -e .
-        pip install -r requirements-test.txt
+        pip install -e . --group test
         pytest

--- a/.github/workflows/testz_numpy_2_compatibility.yml
+++ b/.github/workflows/testz_numpy_2_compatibility.yml
@@ -19,6 +19,5 @@ jobs:
     - name: Install packages
       run: |
         pip install numpy==1.24
-        pip install pytest
         pip install -e . --group test
-        pytest
+        python -m pytest

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -93,9 +93,26 @@ jobs:
           name: wheel-${{ matrix.python }}-${{ matrix.platform_id }}
           path: wheelhouse/*.whl
 
+  sdist_install:
+    name: Test install from sdist
+    needs: make_sdist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v6
+        with:
+          merge-multiple: true
+          path: dist
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Install from sdist
+        run: pip install dist/*.tar.gz
+      - name: Verify import
+        run: python -c "import pyedflib; print('pyedflib', pyedflib.__version__)"
+
   upload_pypi:
     name: Upload to PyPI (prod)
-    needs: [build_wheels, build_aarch64_wheels, make_sdist]
+    needs: [build_wheels, build_aarch64_wheels, make_sdist, sdist_install]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v6

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,13 +6,11 @@ build:
   os: ubuntu-26.04
   tools:
     python: "3.14"
+  jobs:
+    install:
+      - pip install --upgrade pip
+      # Install pyedflib itself so autodoc can import the compiled extension.
+      - pip install --group docs .
 
 sphinx:
   configuration: doc/source/conf.py
-
-python:
-  install:
-    # Since the install step is overridden, pip is no longer updated automatically.
-    - pip install --upgrade pip
-    - pip install --group docs .
-    # Install pyedflib itself so autodoc can import the compiled extension.

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,17 +3,16 @@
 version: 2
 
 build:
-  os: ubuntu-24.04
+  os: ubuntu-26.04
   tools:
-    python: "3.12"
+    python: "3.14"
 
 sphinx:
   configuration: doc/source/conf.py
 
 python:
   install:
-    # Documentation build dependencies (sphinx, numpydoc, ...).
-    - requirements: requirements-doc.txt
+    # Since the install step is overridden, pip is no longer updated automatically.
+    - pip install --upgrade pip
+    - pip install --group docs .
     # Install pyedflib itself so autodoc can import the compiled extension.
-    - method: pip
-      path: .

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,4 @@
 include README-edflib.md
-include LICENSE
 include *.txt
 
 # All source files

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,4 @@
 include README-edflib.md
-include *.txt
 
 # All source files
 recursive-include pyedflib *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,10 +1,6 @@
-include setup.py
-include README.rst
 include README-edflib.md
 include LICENSE
 include *.txt
-include pyproject.toml
-include MANIFEST.in
 
 # All source files
 recursive-include pyedflib *

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,0 @@
-cython
-numpy
-pytest
-dateparser
-tqdm
-tox
-typing_extensions ; python_version < "3.11"

--- a/doc/source/dev/building_extension.rst
+++ b/doc/source/dev/building_extension.rst
@@ -16,6 +16,12 @@ and type the following commands to build and install the package::
 
     pip install .
 
+To install with optional dependency groups::
+
+    pip install --group test .      # Install with test dependencies
+    pip install --group dev .       # Install with development dependencies
+    pip install --group docs .      # Install with documentation dependencies
+
 To verify the installation run the following command::
 
     python -m pytest

--- a/doc/source/dev/building_extension.rst
+++ b/doc/source/dev/building_extension.rst
@@ -14,12 +14,11 @@ repository or use the upstream repository to get the source code::
 Activate your Python virtual environment, go to the cloned source directory
 and type the following commands to build and install the package::
 
-    python setup.py build
-    python setup.py install
+    pip install .
 
 To verify the installation run the following command::
 
-    python setup.py test
+    python -m pytest
 
 To build docs::
 
@@ -39,12 +38,11 @@ Install Microsoft Visual C++ Compiler from https://visualstudio.microsoft.com/do
 Activate your Python virtual environment, go to the cloned source directory
 and type the following commands to build and install the package::
 
-    python setup.py build_ext --inplace
-    python setup.py install --user
+    pip install -e .
 
 To verify the installation run the following command::
 
-    python runtests.py
+    python -m pytest
 
 To build docs::
 

--- a/doc/source/dev/building_extension.rst
+++ b/doc/source/dev/building_extension.rst
@@ -19,8 +19,8 @@ and type the following commands to build and install the package::
 To install with optional dependency groups::
 
     pip install --group test .      # Install with test dependencies
-    pip install --group dev .       # Install with development dependencies
     pip install --group docs .      # Install with documentation dependencies
+    pip install --group dev .       # Install with all development dependencies
 
 To verify the installation run the following command::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,23 @@ dependencies = [
     "numpy>=1.9.1",
 ]
 
+[dependency-groups]
+test = [
+    "coverage",
+    "dateparser",
+    "pytest",
+    "ruff",
+    "tqdm",
+]
+dev = [
+    "tox",
+    "typing_extensions; python_version < '3.11'",
+]
+docs = [
+    "numpydoc",
+    "sphinx",
+]
+
 [project.urls]
 Homepage = "https://github.com/holgern/pyedflib"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,19 +55,20 @@ dependencies = [
 
 [dependency-groups]
 test = [
-    "coverage",
     "dateparser",
     "pytest",
+    "pytest-cov",
     "ruff",
     "tqdm",
-]
-dev = [
-    "tox",
     "typing_extensions; python_version < '3.11'",
 ]
 docs = [
     "numpydoc",
     "sphinx",
+]
+dev = [
+    { include-group = "test" },
+    { include-group = "docs" },
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=61",
+    "setuptools>=77.0.3",
     "numpy>=1.9.1",
     "cython>=0.29",
 ]
@@ -17,14 +17,14 @@ authors = [
 ]
 description = "library to read/write EDF+/BDF+ files"
 readme = "README.rst"
-license = { text = "BSD" }
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Intended Audience :: Education",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: C",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ build-backend = "setuptools.build_meta"
 name = "pyEDFlib"
 maintainers = [
     { name = "Holger Nahrstaedt", email = "nahrstaedt@gmail.com" },
+    { name = "Simon Kern"},
+    { name = "Dimitri Papadopoulos Orfanos"},
 ]
 authors = [
     { name = "Holger Nahrstaedt", email = "nahrstaedt@gmail.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ keywords = [
 dynamic = ["version"]
 dependencies = [
     "numpy>=1.9.1",
+    "typing_extensions; python_version < '3.11'",
 ]
 
 [dependency-groups]
@@ -60,7 +61,6 @@ test = [
     "pytest-cov",
     "ruff",
     "tqdm",
-    "typing_extensions; python_version < '3.11'",
 ]
 docs = [
     "numpydoc",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,80 @@
 [build-system]
 requires = [
-    "setuptools",
+    "setuptools>=61",
     "numpy>=1.9.1",
-    "cython"
+    "cython>=0.29",
 ]
 build-backend = "setuptools.build_meta"
 
+
+[project]
+name = "pyEDFlib"
+maintainers = [
+    { name = "Holger Nahrstaedt", email = "nahrstaedt@gmail.com" },
+]
+authors = [
+    { name = "Holger Nahrstaedt", email = "nahrstaedt@gmail.com" },
+]
+description = "library to read/write EDF+/BDF+ files"
+readme = "README.rst"
+license = { text = "BSD" }
+requires-python = ">=3.9"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Education",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: BSD License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: C",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+keywords = [
+    "EDFlib",
+    "European data format",
+    "EDF",
+    "BDF",
+    "EDF+",
+    "BDF+",
+]
+dynamic = ["version"]
+dependencies = [
+    "numpy>=1.9.1",
+]
+
+[project.urls]
+Homepage = "https://github.com/holgern/pyedflib"
+
+
+[tool.setuptools]
+platforms = ["Windows", "Linux", "Solaris", "Mac OS-X", "Unix"]
+packages = [
+    "pyedflib",
+    "pyedflib._extensions",
+    "pyedflib.data",
+    "pyedflib.tests",
+    "pyedflib.tests.data",
+]
+
+[tool.setuptools.package-data]
+"pyedflib.data" = ["*.edf", "*.bdf"]
+"pyedflib.tests.data" = ["*.edf", "*.bdf"]
+"pyedflib._extensions" = ["*.pyi"]
+
+[tool.setuptools.exclude-package-data]
+"pyedflib._extensions" = ["*.pyx", "*.pxd", "*.pxi", "*.c", "*.h"]
+
+
 [tool.ruff]
-target-version = "py39"
 line-length = 110
 
 [tool.ruff.lint]
@@ -33,7 +100,7 @@ ignore = [
     "DTZ007",  # Naive datetime constructed using `datetime.datetime.strptime()` without %z
     "FA100",   # Add `from __future__ import annotations` to simplify `typing`
     "ISC002",  # Implicitly concatenated string literals over multiple lines
-    "PYI041",  #  Use `float` instead of `int | float`
+    "PYI041",  # Use `float` instead of `int | float`
     "PERF203", # `try`-`except` within a loop incurs performance overhead
     "RUF003",
     "RUF005",  # Consider iterable unpacking instead of concatenation
@@ -41,4 +108,3 @@ ignore = [
 
 [tool.ruff.lint.extend-per-file-ignores]
 "**/__init__.py" = ["F401", "F403"]
-"setup.py" = ["SIM115", "SIM117"]

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,5 +1,0 @@
-cython
-numpy
-pytest
-sphinx
-numpydoc

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,0 @@
-coverage
-cython
-numpy
-pytest
-dateparser
-tqdm
-ruff

--- a/setup.py
+++ b/setup.py
@@ -184,14 +184,13 @@ make_ext_path = partial(os.path.join, "pyedflib", "_extensions")
 
 if os.name == "nt":
     # Patch edflib.c
-    with open(make_ext_path("c/edflib.c"), "rb") as fin:
-        with open(make_ext_path("c/edflib_utf8.c"), "wb") as fout:
-            for line in fin:
-                line = line.replace(b'#include "edflib.h"', b'#include "edflib.h"\r\n#include "fopen_utf8.h"')
-                line = line.replace(b'file = fopeno(path, "rb");', b'file = fopen_utf8(path, "rb");')
-                line = line.replace(b'file = fopeno(path, "wb");', b'file = fopen_utf8(path, "wb");')
+    with open(make_ext_path("c/edflib.c"), "rb") as fin, open(make_ext_path("c/edflib_utf8.c"), "wb") as fout:
+        for line in fin:
+            line = line.replace(b'#include "edflib.h"', b'#include "edflib.h"\r\n#include "fopen_utf8.h"')
+            line = line.replace(b'file = fopeno(path, "rb");', b'file = fopen_utf8(path, "rb");')
+            line = line.replace(b'file = fopeno(path, "wb");', b'file = fopen_utf8(path, "wb");')
 
-                fout.write(line)
+            fout.write(line)
 
     sources = ["c/edflib_utf8.c", "c/fopen_utf8.c"]
     headers = ["c/edflib.h", "c/fopen_utf8.h"]
@@ -293,50 +292,8 @@ if __name__ == "__main__":
         ext_modules = cythonize(ext_modules, compiler_directives=cythonize_opts)
 
     setup(
-        name="pyEDFlib",
-        maintainer="Holger Nahrstaedt",
-        maintainer_email="nahrstaedt@gmail.com",
-        author="Holger Nahrstaedt",
-        author_email="nahrstaedt@gmail.com",
-        url="https://github.com/holgern/pyedflib",
-        license="BSD",
-        description="library to read/write EDF+/BDF+ files",
-        long_description=open("README.rst").read(),
-        keywords=["EDFlib", "European data format", "EDF", "BDF", "EDF+", "BDF+"],
-        classifiers=[
-            "Development Status :: 5 - Production/Stable",
-            "Intended Audience :: Developers",
-            "Intended Audience :: Education",
-            "Intended Audience :: Science/Research",
-            "License :: OSI Approved :: BSD License",
-            "Operating System :: OS Independent",
-            "Programming Language :: Python :: Implementation :: CPython",
-            "Programming Language :: C",
-            "Programming Language :: Python",
-            "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "Programming Language :: Python :: 3.11",
-            "Programming Language :: Python :: 3.12",
-            "Programming Language :: Python :: 3.13",
-            "Programming Language :: Python :: 3.14",
-            "Topic :: Software Development :: Libraries :: Python Modules",
-        ],
-        platforms=["Windows", "Linux", "Solaris", "Mac OS-X", "Unix"],
         version=get_version_info()[0],
-        packages=[
-            "pyedflib",
-            "pyedflib._extensions",
-            "pyedflib.data",
-            "pyedflib.tests",
-            "pyedflib.tests.data",
-        ],
-        package_data={
-            "pyedflib.data": ["*.edf", "*.bdf"],
-            "pyedflib.tests.data": ["*.edf", "*.bdf"],
-        },
         ext_modules=ext_modules,
         libraries=[c_lib],
         cmdclass={"develop": develop_build_clib},
-        install_requires=[REQUIRED_NUMPY],
     )


### PR DESCRIPTION
Also apply PEP 639 and 735 to update metadata.

Alternative to #298: it seems simpler to keep a minimal `setup.py`. Also, let's defer version handling with `setuptools-scm` to a later PR.

Fixes https://github.com/holgern/pyedflib/issues/225.